### PR TITLE
fix: escape jq key quotes for ALLOW_META_IP_ADDRESS in entrypoint.sh

### DIFF
--- a/build/scripts/entrypoint.sh
+++ b/build/scripts/entrypoint.sh
@@ -66,8 +66,8 @@ fi
 [ -n "$ALLOW_PRIVATE_IP_ADDRESS" ] && \
   jq_filter="$jq_filter | .services.CoAuthoring[\"request-filtering-agent\"].allowPrivateIPAddress = true"
 
-[ -n "$ALLOW_META_IP_ADDRESS" ] &&\
-  jq_filter="$jq_filter | .services.CoAuthoring["request-filtering-agent"].allowMetaIPAddress = true"
+[ -n "$ALLOW_META_IP_ADDRESS" ] && \
+  jq_filter="$jq_filter | .services.CoAuthoring[\"request-filtering-agent\"].allowMetaIPAddress = true"
 
 if [ "$jq_filter" != "." ]; then
   jq \


### PR DESCRIPTION
Fixes a shell quoting issue in the `ALLOW_META_IP_ADDRESS` handler in `entrypoint.sh`.

The `ALLOW_PRIVATE_IP_ADDRESS` branch (line 68) correctly escapes the inner quotes for the `request-filtering-agent` jq key:

```shell
jq_filter="$jq_filter | .services.CoAuthoring[\"request-filtering-agent\"].allowPrivateIPAddress = true"
```
The `ALLOW_META_IP_ADDRESS` branch (line 71) does not escape them, causing shell string splitting. The resulting jq filter contains `CoAuthoring[request-filtering-agent]` without quotes, which jq evaluates as arithmetic (three undefined variables → `0`), resolving to `CoAuthoring[0]` instead of the intended object key.

This can produce a malformed `local.json` at container startup when `ALLOW_META_IP_ADDRESS` is set.

Fix: add `\"` escaping to match the line above.