### PR TITLE
Fix broken fork references and update branding in documentation

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,13 +1,13 @@
 # Euro-Office Document Server
 
-Docker image where we are experimenting with building the OnlyOffice Document Server.
+Docker image where we are experimenting with building the Euro-Office Document Server.
 
 ## Building the Image
 
 First, clone the repositories for the core-fonts, sdkjs, web-apps, and server components:
 
 ```sh
-git clone --recurse-submodules https://github.com/Euro-Office/fork.git
+git clone --recurse-submodules https://github.com/Euro-Office/DocumentServer.git
 ```
 
 If the repo was cloned without --recurse-submodules, initialize and download the submodules with:
@@ -18,14 +18,14 @@ git submodule update --init --recursive
 Then, you can build the full image by running:
 
 ```sh
-cd fork/build
+cd DocumentServer/build
 make build-image
 ```
 
 or the development image with:
 
 ```sh
-cd fork/build
+cd DocumentServer/build
 make build
 ```
 
@@ -68,7 +68,7 @@ The version is read from the `VERSION` file at the repo root. An optional
 ### Basic build
 
 ```sh
-cd fork/build
+cd DocumentServer/build
 make packages
 ```
 

--- a/develop/README.md
+++ b/develop/README.md
@@ -4,12 +4,12 @@
 The docker compose environment in this directory allows to run document server built from our code base. It runs a container called develop, which just adds the development (i.e., build) tooling to the finalubuntu container. This lets you build pieces on the fly directly inside the container, saving build time when developing:
 
 - Follow the repo cloning steps in the build readme
-- In fork/develop, start the containers and get into eo bash with either: 
+- In DocumentServer/develop, start the containers and get into eo bash with either: 
   - `make` to use the image that is currently available locally
   - `make pull` to use the latest image from github
   - `make build` to build the image locally from scratch
   
-  You may need to generate a PAT first, as described in https://github.com/Euro-Office/fork/pkgs/container/documentserver
+  You may need to generate a PAT first, as described in https://github.com/Euro-Office/DocumentServer/pkgs/container/documentserver
 - In docker-compose.yml, for the eo service, ensure that `target` is set to `develop`
 
 #### Using the image:


### PR DESCRIPTION
Closes #19

## Summary

- Fix broken clone URL in build/README.md (Euro-Office/fork.git does not exist)
- Replace fork/ directory references with DocumentServer/ in build/ and develop/ READMEs
- Update outdated OnlyOffice branding to Euro-Office in documentation