### PR TITLE
build: Add script to tag releases accross repos

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -110,3 +110,24 @@ make vagrant-ssh VM=ubuntu2404
 # Destroy all VMs
 make vagrant-destroy
 ```
+
+## Tagging a release
+
+The `scripts/tag_release.sh` script creates semver pre-release tags
+(`vX.Y.Z-ID.BUILD`) on the main repo and all submodules. The version is read
+from the `VERSION` file at the repo root.
+
+```sh
+# Auto-increment: finds the last -tp.N tag and bumps to N+1
+../scripts/tag_release.sh --dry-run
+../scripts/tag_release.sh
+
+# Explicit build number
+../scripts/tag_release.sh -b 5
+
+# Custom pre-release identifier (default: tp)
+../scripts/tag_release.sh -p rc        # → v9.3.1-rc.1
+
+# Create and push tags to remotes
+../scripts/tag_release.sh --push
+```

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION_FILE="$REPO_ROOT/VERSION"
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "ERROR: VERSION file not found at $VERSION_FILE"
+    exit 1
+fi
+
+VERSION="$(cat "$VERSION_FILE" | tr -d '[:space:]')"
+
+# Validate semver format (major.minor.patch)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: VERSION '$VERSION' is not valid semver (expected X.Y.Z)"
+    exit 1
+fi
+
+# Parse arguments
+DRY_RUN=0
+BUILD_NUMBER=""
+PRE_ID="tp"
+PUSH=0
+
+usage() {
+    echo "Usage: $0 [-b BUILD_NUMBER] [--dry-run] [--push]"
+    echo ""
+    echo "Tags the main repo and all submodules with vVERSION-ID.BUILD_NUMBER"
+    echo ""
+    echo "Options:"
+    echo "  -b, --build BUILD_NUMBER   Build number (default: last build + 1)"
+    echo "  -p, --pre-id ID            Pre-release identifier (default: tp)"
+    echo "  --dry-run                  Print tags without creating them"
+    echo "  --push                     Push tags to remote after creating"
+    echo "  -h, --help                 Show this help"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -b|--build)
+            BUILD_NUMBER="$2"
+            shift 2
+            ;;
+        -p|--pre-id)
+            PRE_ID="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --push)
+            PUSH=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$BUILD_NUMBER" ]; then
+    # Find the highest existing build number for this version
+    LAST_BUILD=$(git -C "$REPO_ROOT" tag --list "v${VERSION}-${PRE_ID}.*" \
+        | sed "s/^v${VERSION}-${PRE_ID}\.//" \
+        | sort -n \
+        | tail -1)
+    if [ -z "$LAST_BUILD" ]; then
+        BUILD_NUMBER=1
+    else
+        BUILD_NUMBER=$((LAST_BUILD + 1))
+    fi
+    echo "Auto-detected build number: $BUILD_NUMBER (last: ${LAST_BUILD:-none})"
+fi
+
+if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: Build number must be a positive integer"
+    exit 1
+fi
+
+TAG="v${VERSION}-${PRE_ID}.${BUILD_NUMBER}"
+
+tag_repo() {
+    local repo_path="$1"
+    local repo_name="$2"
+    local tag="$3"
+
+    if git -C "$repo_path" rev-parse "$tag" >/dev/null 2>&1; then
+        echo "  SKIP $repo_name — tag $tag already exists"
+        return 0
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "  [DRY RUN] Would tag $repo_name at $(git -C "$repo_path" rev-parse --short HEAD) as $tag"
+    else
+        git -C "$repo_path" tag -a "$tag" -m "Release $tag"
+        echo "  Tagged $repo_name at $(git -C "$repo_path" rev-parse --short HEAD) as $tag"
+    fi
+
+    if [ "$PUSH" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
+        git -C "$repo_path" push origin "$tag"
+        echo "  Pushed $tag for $repo_name"
+    fi
+}
+
+echo "Tagging release: $TAG"
+echo ""
+
+# Tag main repository
+echo "Main repository:"
+tag_repo "$REPO_ROOT" "DocumentServer" "$TAG"
+echo ""
+
+# Tag each submodule
+echo "Submodules:"
+git -C "$REPO_ROOT" submodule foreach --quiet 'echo $sm_path' | while read -r sm_path; do
+    sm_full_path="$REPO_ROOT/$sm_path"
+    tag_repo "$sm_full_path" "$sm_path" "$TAG"
+done
+
+echo ""
+echo "Done."


### PR DESCRIPTION
This allows us to push tags that then trigger a build of containers. For now using `tp` as tech-preview build identifier, but we can switch to others if needed.