### PR TITLE
Fix translations missing for non en locale

### DIFF
--- a/develop/setup/Makefile
+++ b/develop/setup/Makefile
@@ -48,6 +48,8 @@ endif
 
 web-apps:
 	@echo "Building web-apps with flags $(CFLAGS)"
+	cd $(EO_DEV)/web-apps/translation && \
+	python3 merge_and_check.py && \
 	cd $(EO_DEV)/web-apps/build && \
 	npm ci && \
 	BUILD_ROOT=$(EO_ROOT) grunt $(SKIP_IMAGEMIN) $(CFLAGS)
@@ -55,6 +57,8 @@ web-apps:
 
 web-apps-dev:
 	$(CHECK_WEBAPPS_DEPS)
+	cd $(EO_DEV)/web-apps/translation && \
+	python3 merge_and_check.py && \
 	cd $(EO_DEV)/web-apps/build && \
 	BUILD_ROOT=$(EO_ROOT) grunt $(SKIP_IMAGEMIN) --skip-babel $(CFLAGS)
 	$(FLUSH_CACHE)


### PR DESCRIPTION
Onlyoffice's build_tools has [an extra step](https://github.com/ONLYOFFICE/build_tools/blob/c5f6c2e02b50dfcc5c53a207f9a6cde84896de91/scripts/build_js.py#L49) that adds missing keys in the locale files using en.json as the default.

If a key is missing from the locale file, it leads to weird edge cases, here's what I'm aware of:
- In nl.json, the document editor doesn't load (https://github.com/NixOS/nixpkgs/pull/501328#issuecomment-4096639775)
- In fr.json , the tooltip showing off the new multipage feature has a title and a description that is irrelevant. 

This PR execute the `merge_and_check.py` script when building web-apps. 