### PR TITLE
fix(build): bump CACHE_BUST to 3 and update core submodule

### DIFF
--- a/build/docker-bake.hcl
+++ b/build/docker-bake.hcl
@@ -33,7 +33,7 @@ variable "NUGET_SOURCE_PATH" {
 }
 
 variable "CACHE_BUST" {
-  default = "2"
+  default = "3"
 }
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
- CACHE_BUST 2→3 forces a new wasm-build-cache-3 Docker mount, which causes core-wasm stage to fully recompile fonts.wasm and fonts.js from the updated module_js.js (onRuntimeInitialized fix).
- Update core submodule pointer to include the FT_* timing fix.