### PR TITLE
Feat/support android dev ips

### DIFF
--- a/develop/Makefile
+++ b/develop/Makefile
@@ -1,7 +1,21 @@
 PRODUCT_VERSION ?= $(shell cat ../VERSION)
 export PRODUCT_VERSION
 
+# Host LAN IP so phones/emulators/LAN devices can reach DocumentServer and
+# Nextcloud via the desktop's routable address rather than localhost.
+ifeq ($(shell uname -s),Darwin)
+	DETECTED_HOST_LAN_IP := $(shell ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null)
+else
+	# 1.1.1.1 is a dummy public target — `ip route get` just asks the kernel
+	# which local source IP it would use, without actually sending packets.
+	DETECTED_HOST_LAN_IP := $(shell ip route get 1.1.1.1 2>/dev/null | awk '{print $$7; exit}')
+endif
+HOST_LAN_IP ?= $(DETECTED_HOST_LAN_IP)
+export HOST_LAN_IP
+
 local:
+	@echo "Host LAN IP: $(or $(HOST_LAN_IP),<not detected>)"
+	@echo "If your network changes, run: make refresh-urls"
 	docker compose up -d && docker compose exec eo bash
 
 pull:
@@ -11,3 +25,10 @@ build:
 	(cd ../build && docker buildx bake develop) && \
 	(docker compose up -d) && \
 	(docker compose exec eo bash)
+
+# Re-point OnlyOffice URLs and trusted_domains at the current HOST_LAN_IP
+# without wiping the stack. Use after your LAN IP changes (new wifi, etc.).
+refresh-urls:
+	@test -n "$(HOST_LAN_IP)" || { echo "HOST_LAN_IP could not be detected; pass it explicitly: make refresh-urls HOST_LAN_IP=1.2.3.4"; exit 1; }
+	docker compose exec -u www-data nextcloud ./occ config:app:set onlyoffice DocumentServerUrl --value="http://$(HOST_LAN_IP):8080/"
+	docker compose exec -u www-data nextcloud ./occ config:system:set trusted_domains 2 --value=$(HOST_LAN_IP)

--- a/develop/Makefile
+++ b/develop/Makefile
@@ -14,8 +14,19 @@ HOST_LAN_IP ?= $(DETECTED_HOST_LAN_IP)
 export HOST_LAN_IP
 
 local:
-	@echo "Host LAN IP: $(or $(HOST_LAN_IP),<not detected>)"
-	@echo "If your network changes, run: make refresh-urls"
+	@echo ""
+	@echo "   ███████╗ ██████╗"
+	@echo "   ██╔════╝██╔═══██╗"
+	@echo "   █████╗  ██║   ██║"
+	@echo "   ██╔══╝  ██║   ██║"
+	@echo "   ███████╗╚██████╔╝"
+	@echo "   ╚══════╝ ╚═════╝"
+	@echo ""
+	@echo "   Euro-Office Development Environment"
+	@echo ""
+	@echo "   Host LAN IP:   $(or $(HOST_LAN_IP),<not detected>)"
+	@echo "   On IP change:  make refresh-urls"
+	@echo ""
 	docker compose up -d && docker compose exec eo bash
 
 pull:

--- a/develop/Makefile
+++ b/develop/Makefile
@@ -1,8 +1,8 @@
 PRODUCT_VERSION ?= $(shell cat ../VERSION)
 export PRODUCT_VERSION
 
-# Host LAN IP so phones/emulators/LAN devices can reach DocumentServer and
-# Nextcloud via the desktop's routable address rather than localhost.
+# Detect host LAN IP for phones/emulators/LAN devices. Used by `make mobile`
+# and `make refresh-urls`.
 ifeq ($(shell uname -s),Darwin)
 	DETECTED_HOST_LAN_IP := $(shell ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null)
 else
@@ -10,7 +10,10 @@ else
 	# which local source IP it would use, without actually sending packets.
 	DETECTED_HOST_LAN_IP := $(shell ip route get 1.1.1.1 2>/dev/null | awk '{print $$7; exit}')
 endif
-HOST_LAN_IP ?= $(DETECTED_HOST_LAN_IP)
+
+# Empty by default: `make local` runs on localhost (desktop browser + iOS sim).
+# `make mobile` sets this so Android emulators and LAN-connected devices can reach the editor.
+HOST_LAN_IP ?=
 export HOST_LAN_IP
 
 local:
@@ -24,10 +27,23 @@ local:
 	@echo ""
 	@echo "   Euro-Office Development Environment"
 	@echo ""
-	@echo "   Host LAN IP:   $(or $(HOST_LAN_IP),<not detected>)"
+ifeq ($(HOST_LAN_IP),)
+	@echo "   Mode: localhost (desktop browser + iOS sim)"
+	@echo "   For Android / physical device testing: make mobile"
+else
+	@echo "   Mode: mobile / LAN"
+	@echo "   Host LAN IP:   $(HOST_LAN_IP)"
 	@echo "   On IP change:  make refresh-urls"
+endif
 	@echo ""
-	docker compose up -d && docker compose exec eo bash
+	docker compose up -d
+	@$(MAKE) --no-print-directory refresh-urls
+	docker compose exec eo bash
+
+# Like `make local`, but injects the detected HOST_LAN_IP so that Nextcloud
+# returns a DocumentServerUrl mobile/LAN clients can actually reach.
+mobile:
+	@HOST_LAN_IP="$(DETECTED_HOST_LAN_IP)" $(MAKE) local
 
 pull:
 	docker compose pull && docker compose up -d && docker compose exec eo bash
@@ -37,9 +53,28 @@ build:
 	(docker compose up -d) && \
 	(docker compose exec eo bash)
 
-# Re-point OnlyOffice URLs and trusted_domains at the current HOST_LAN_IP
-# without wiping the stack. Use after your LAN IP changes (new wifi, etc.).
+# Align OnlyOffice URLs and trusted_domains with the current mode.
+# - If HOST_LAN_IP is set: mobile/LAN mode (DocumentServerUrl = http://<ip>:8080/, trusted_domains[2] = <ip>).
+# - If HOST_LAN_IP is empty: localhost mode (DocumentServerUrl = http://localhost:8080/, trusted_domains[2] cleared).
+# Waits for Nextcloud + OnlyOffice to finish installing on first boot, then applies idempotently.
 refresh-urls:
-	@test -n "$(HOST_LAN_IP)" || { echo "HOST_LAN_IP could not be detected; pass it explicitly: make refresh-urls HOST_LAN_IP=1.2.3.4"; exit 1; }
-	docker compose exec -u www-data nextcloud ./occ config:app:set onlyoffice DocumentServerUrl --value="http://$(HOST_LAN_IP):8080/"
-	docker compose exec -u www-data nextcloud ./occ config:system:set trusted_domains 2 --value=$(HOST_LAN_IP)
+	@start=$$(date +%s); \
+	  while ! docker compose exec -T eo curl -sf http://localhost/healthcheck >/dev/null 2>&1; do \
+	    printf "\rWaiting for document server (%ds)   " $$(($$(date +%s) - start)); \
+	    sleep 2; \
+	  done; \
+	  printf "\rDocument server ready (%ds).          \n" $$(($$(date +%s) - start))
+	@start=$$(date +%s); \
+	  while ! docker compose exec -T -u www-data nextcloud ./occ config:app:get onlyoffice DocumentServerUrl 2>/dev/null | grep -q "http"; do \
+	    printf "\rWaiting for Nextcloud setup (%ds)   " $$(($$(date +%s) - start)); \
+	    sleep 2; \
+	  done; \
+	  printf "\rNextcloud setup ready (%ds).          \n" $$(($$(date +%s) - start))
+	@target="$${HOST_LAN_IP:-localhost}"; \
+	  echo "Setting DocumentServerUrl to http://$$target:8080/"; \
+	  docker compose exec -T -u www-data nextcloud ./occ config:app:set onlyoffice DocumentServerUrl --value="http://$$target:8080/" >/dev/null; \
+	  if [ "$$target" = "localhost" ]; then \
+	    docker compose exec -T -u www-data nextcloud ./occ config:system:delete trusted_domains 2 >/dev/null 2>&1 || true; \
+	  else \
+	    docker compose exec -T -u www-data nextcloud ./occ config:system:set trusted_domains 2 --value=$$target >/dev/null; \
+	  fi

--- a/develop/README.md
+++ b/develop/README.md
@@ -24,6 +24,26 @@ The docker compose environment in this directory allows to run document server b
         - Secret key: `secret`
     - Navigate to Files `http://localhost:8081/apps/files/`, create a document, and try to open it
 
+#### Testing from mobile devices and emulators
+
+`make local` auto-detects the host's LAN IP (`HOST_LAN_IP`) so phones, tablets, and simulators/emulators can reach the editor — `localhost` only works from the desktop itself.
+
+- **iOS simulator & desktop browser**: reach Nextcloud at `http://localhost:8081/` as usual.
+- **Android emulator**: log in at `http://10.0.2.2:8081/` (the emulator's alias for the host). Already trusted by the stack.
+- **Physical device on the same LAN**: log in at `http://<HOST_LAN_IP>:8081/`. `HOST_LAN_IP` is appended to Nextcloud's trusted domains automatically.
+
+Detection uses `ipconfig` on macOS and `ip route` on Linux. On native Windows — or any machine where detection fails — pass it explicitly:
+
+```sh
+make local HOST_LAN_IP=192.168.1.50
+```
+
+When your LAN IP changes (new wifi, tethering, etc.), update the running stack without a full rebuild:
+
+```sh
+make refresh-urls
+```
+
 #### Building changes:
 
 - Enter the container with `docker compose exec eo bash`

--- a/develop/README.md
+++ b/develop/README.md
@@ -8,6 +8,7 @@ The docker compose environment in this directory allows to run document server b
   - `make` to use the image that is currently available locally
   - `make pull` to use the latest image from github
   - `make build` to build the image locally from scratch
+  - `make mobile` for Android emulator / physical LAN device testing (see below)
   
   You may need to generate a PAT first, as described in https://github.com/Euro-Office/DocumentServer/pkgs/container/documentserver
 - In docker-compose.yml, for the eo service, ensure that `target` is set to `develop`
@@ -26,16 +27,19 @@ The docker compose environment in this directory allows to run document server b
 
 #### Testing from mobile devices and emulators
 
-`make local` auto-detects the host's LAN IP (`HOST_LAN_IP`) so phones, tablets, and simulators/emulators can reach the editor — `localhost` only works from the desktop itself.
+`make local` runs on `localhost` — enough for the desktop browser and iOS simulator. For Android emulators and physical devices on the LAN, use `make mobile` instead — it detects the host's LAN IP and injects it so the editor is reachable from off-desktop clients.
 
-- **iOS simulator & desktop browser**: reach Nextcloud at `http://localhost:8081/` as usual.
-- **Android emulator**: log in at `http://10.0.2.2:8081/` (the emulator's alias for the host). Already trusted by the stack.
-- **Physical device on the same LAN**: log in at `http://<HOST_LAN_IP>:8081/`. `HOST_LAN_IP` is appended to Nextcloud's trusted domains automatically.
+| Client | Target | Nextcloud URL |
+|---|---|---|
+| Desktop browser | `make local` or `make mobile` | `http://localhost:8081/` |
+| iOS simulator | `make local` or `make mobile` | `http://localhost:8081/` |
+| Android emulator | `make mobile` | `http://10.0.2.2:8081/` |
+| Physical LAN device | `make mobile` | `http://<HOST_LAN_IP>:8081/` |
 
-Detection uses `ipconfig` on macOS and `ip route` on Linux. On native Windows — or any machine where detection fails — pass it explicitly:
+IP detection uses `ipconfig` on macOS and `ip route` on Linux. On native Windows — or any machine where detection fails — pass it explicitly:
 
 ```sh
-make local HOST_LAN_IP=192.168.1.50
+make mobile HOST_LAN_IP=192.168.1.50
 ```
 
 When your LAN IP changes (new wifi, tethering, etc.), update the running stack without a full rebuild:
@@ -43,6 +47,8 @@ When your LAN IP changes (new wifi, tethering, etc.), update the running stack w
 ```sh
 make refresh-urls
 ```
+
+Switching between `make local` and `make mobile` on an already-started stack is supported — both targets re-apply the correct URLs and trusted domains on each run.
 
 #### Building changes:
 

--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -31,9 +31,10 @@ services:
       - /var/www/html
       - ./setup/enable-office.sh:/docker-entrypoint-hooks.d/post-installation/enable-office.sh:ro
     environment:
-      # 10.0.2.2 = Android emulator's alias for host; HOST_LAN_IP = LAN devices / phones.
-      NEXTCLOUD_TRUSTED_DOMAINS: 10.0.2.2 ${HOST_LAN_IP:-}
-      HOST_LAN_IP: ${HOST_LAN_IP:-}
+      # 10.0.2.2 = Android emulator's alias for host. Mobile/LAN IPs are
+      # applied post-boot by `make refresh-urls` so the container env stays
+      # stable across mode switches (no recreation, no data loss).
+      NEXTCLOUD_TRUSTED_DOMAINS: 10.0.2.2
       SQLITE_DATABASE: nextcloud
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin

--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -31,7 +31,9 @@ services:
       - /var/www/html
       - ./setup/enable-office.sh:/docker-entrypoint-hooks.d/post-installation/enable-office.sh:ro
     environment:
-      NEXTCLOUD_TRUSTED_DOMAINS: 10.0.2.2 #Android emulator map to localhost
+      # 10.0.2.2 = Android emulator's alias for host; HOST_LAN_IP = LAN devices / phones.
+      NEXTCLOUD_TRUSTED_DOMAINS: 10.0.2.2 ${HOST_LAN_IP:-}
+      HOST_LAN_IP: ${HOST_LAN_IP:-}
       SQLITE_DATABASE: nextcloud
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin

--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - /var/www/html
       - ./setup/enable-office.sh:/docker-entrypoint-hooks.d/post-installation/enable-office.sh:ro
     environment:
-      NEXTCLOUD_TRUSTED_DOMAINS: 172.18.0.1 
+      NEXTCLOUD_TRUSTED_DOMAINS: 10.0.2.2 #Android emulator map to localhost
       SQLITE_DATABASE: nextcloud
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin

--- a/develop/setup/enable-office.sh
+++ b/develop/setup/enable-office.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-php /var/www/html/occ config:system:set trusted_domains 2 --value=nextcloud
+php /var/www/html/occ config:system:set trusted_domains 10 --value=nextcloud
 
 echo "Waiting for Euro-Office document server to be ready..."
 until curl -sf http://eo/healthcheck > /dev/null 2>&1; do
@@ -9,8 +9,10 @@ until curl -sf http://eo/healthcheck > /dev/null 2>&1; do
 done
 echo "Document server is ready!"
 
+DOCUMENT_SERVER_HOST="${HOST_LAN_IP:-localhost}"
+
 php /var/www/html/occ app:enable onlyoffice
-php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="http://localhost:8080/"
+php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="http://${DOCUMENT_SERVER_HOST}:8080/"
 php /var/www/html/occ config:app:set onlyoffice StorageUrl --value="http://nextcloud/"
 php /var/www/html/occ config:app:set onlyoffice DocumentServerInternalUrl --value="http://eo/"
 php /var/www/html/occ config:app:set onlyoffice VerifyPeerOff --value="true"

--- a/develop/setup/enable-office.sh
+++ b/develop/setup/enable-office.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-php /var/www/html/occ config:system:set trusted_domains 1 --value=nextcloud
+php /var/www/html/occ config:system:set trusted_domains 2 --value=nextcloud
 
 echo "Waiting for Euro-Office document server to be ready..."
 until curl -sf http://eo/healthcheck > /dev/null 2>&1; do

--- a/develop/setup/enable-office.sh
+++ b/develop/setup/enable-office.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-php /var/www/html/occ config:system:set trusted_domains 2 --value=nextcloud
+php /var/www/html/occ config:system:set trusted_domains 10 --value=nextcloud
+
+# Disable throttling for dev — mobile login retries trip the default
+# brute-force protection and rate limiter, blocking further requests.
+php /var/www/html/occ config:system:set auth.bruteforce.protection.enabled --value=false --type=boolean
+php /var/www/html/occ config:system:set ratelimit.protection.enabled --value=false --type=boolean
 
 echo "Waiting for Euro-Office document server to be ready..."
 until curl -sf http://eo/healthcheck > /dev/null 2>&1; do
@@ -9,10 +14,9 @@ until curl -sf http://eo/healthcheck > /dev/null 2>&1; do
 done
 echo "Document server is ready!"
 
-DOCUMENT_SERVER_HOST="${HOST_LAN_IP:-localhost}"
-
+# Baseline URL; `make local` / `make mobile` rewrite this via `refresh-urls`.
 php /var/www/html/occ app:enable onlyoffice
-php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="http://${DOCUMENT_SERVER_HOST}:8080/"
+php /var/www/html/occ config:app:set onlyoffice DocumentServerUrl --value="http://localhost:8080/"
 php /var/www/html/occ config:app:set onlyoffice StorageUrl --value="http://nextcloud/"
 php /var/www/html/occ config:app:set onlyoffice DocumentServerInternalUrl --value="http://eo/"
 php /var/www/html/occ config:app:set onlyoffice VerifyPeerOff --value="true"

--- a/develop/setup/enable-office.sh
+++ b/develop/setup/enable-office.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-php /var/www/html/occ config:system:set trusted_domains 10 --value=nextcloud
+php /var/www/html/occ config:system:set trusted_domains 2 --value=nextcloud
 
 echo "Waiting for Euro-Office document server to be ready..."
 until curl -sf http://eo/healthcheck > /dev/null 2>&1; do


### PR DESCRIPTION
Closes https://github.com/Euro-Office/DocumentServer/issues/74

Testing on desktop browsers is fine. Testing on Mac + simulated iPhone is also fine. As is iPhone in Nextcloud App.

However, Android is not fine. Android maps 10.0.2.2 to localhost, this doesn't work.

We have to do two things

1) Ensure 10.0.2.2 is allowed

2) Set the DocumentServerUrl to something accessible on the local net as it gets set to the OO iframe

Impl:

1) add Android dev IP to trusted and ensure that config doesn't overwrite this. (also removes a previous value there that was being overwritten)

~~2) As we need the actual IP, get this and also introduce a way to keep this updated - when networks change without having to pull docker all down etc - as part of make local this happens, and also adds make refresh to allow quick updates if needed.~~ Made nicer approach using `make mobile` - one time docker update, then it is there

This way, everything works :)

### Testing

Inside DocumentServer/develop:

`docker down -v` - This is remove existing EO so, you might want to do this on a version you aren't dev'ing on. **One time thing.**

`make local` - runs as normal

`make mobile` - uses localhost for desktop, but will also work for Android devices simulated via Android Studio (can use the IP make mobile provides, or 10.0.2.2 - the one Android Studio maps to localhost)

Switch between the two to your heart's content. Testing as appropriate.