### PR TITLE
Create default PostgreSQL cluster (required before starting the service)

### DIFF
--- a/build/.docker/docserver.bake.Dockerfile
+++ b/build/.docker/docserver.bake.Dockerfile
@@ -35,6 +35,9 @@ RUN useradd -r -s /bin/false ds || true
 
 COPY build/configs/postgres ${EO_ROOT}/server/schema/postgresql
 
+# Create default PostgreSQL cluster (required before starting the service)
+RUN pg_createcluster 16 main || true
+
 RUN service postgresql start && \
     sudo -u postgres psql -c "CREATE USER onlyoffice WITH password 'onlyoffice';" && \
     sudo -u postgres psql -c "CREATE DATABASE onlyoffice OWNER onlyoffice;" && \


### PR DESCRIPTION
Fix PostgreSQL initialization in Docker build: add missing cluster creation (pg_createcluster), otherwise service start fails with "No PostgreSQL clusters exist"