### PR TITLE
Feat/enhance make dx

### DIFF
--- a/develop/Makefile
+++ b/develop/Makefile
@@ -35,18 +35,19 @@ ifeq ($(HOST_LAN_IP),)
 	@echo "   For Android / physical device testing: make mobile"
 else
 	@echo "   Mode: mobile / LAN"
-	@echo "   Host LAN IP:   $(HOST_LAN_IP)"
+	@echo "   Nextcloud:     http://$(HOST_LAN_IP):8081/"
 	@echo "   On IP change:  make refresh-urls"
 endif
+	@echo "   Volume:    nc_data_$${NC_VERSION:-latest}  (wipe with: make wipe-nc NC_VERSION=$${NC_VERSION:-latest})"
 	@echo ""
 	docker compose up -d
 	@if [ "$$(docker inspect --format '{{.State.Status}}' nextcloud 2>/dev/null)" != "running" ]; then \
 	  if docker compose logs nextcloud 2>&1 | grep -q "version of the data"; then \
 	    echo ""; \
-	    echo "   WARNING: Nextcloud failed to start — your local nextcloud:latest image is"; \
+	    echo "   WARNING: Nextcloud failed to start — your local nextcloud:$${NC_VERSION:-latest} image is"; \
 	    echo "   behind the data volume. Pull the latest image and retry:"; \
 	    echo ""; \
-	    echo "      docker pull nextcloud:latest && make"; \
+	    echo "      docker pull nextcloud:$${NC_VERSION:-latest} && make"; \
 	    echo ""; \
 	    exit 1; \
 	  fi; \

--- a/develop/Makefile
+++ b/develop/Makefile
@@ -40,6 +40,17 @@ else
 endif
 	@echo ""
 	docker compose up -d
+	@if [ "$$(docker inspect --format '{{.State.Status}}' nextcloud 2>/dev/null)" != "running" ]; then \
+	  if docker compose logs nextcloud 2>&1 | grep -q "version of the data"; then \
+	    echo ""; \
+	    echo "   WARNING: Nextcloud failed to start — your local nextcloud:latest image is"; \
+	    echo "   behind the data volume. Pull the latest image and retry:"; \
+	    echo ""; \
+	    echo "      docker pull nextcloud:latest && make"; \
+	    echo ""; \
+	    exit 1; \
+	  fi; \
+	fi
 	@$(MAKE) --no-print-directory refresh-urls
 	@$(MAKE) --no-print-directory print-nc-version
 	@docker compose exec eo bash || true

--- a/develop/Makefile
+++ b/develop/Makefile
@@ -97,13 +97,27 @@ build:
 refresh-urls:
 	@start=$$(date +%s); \
 	  while ! docker compose exec -T eo curl -sf http://localhost/healthcheck >/dev/null 2>&1; do \
+	    if [ "$$(docker inspect --format '{{.State.Status}}' eo 2>/dev/null)" != "running" ]; then \
+	      printf "\r[eo]        failed — check: docker compose logs eo\n"; \
+	      exit 1; \
+	    fi; \
 	    printf "\r[eo]        waiting     (%ds)   " $$(($$(date +%s) - start)); \
 	    sleep 2; \
 	  done; \
 	  printf "\r[eo]        ready        (%ds)        \n" $$(($$(date +%s) - start))
 	@start=$$(date +%s); \
 	  while ! docker compose exec -T -u www-data nextcloud ./occ config:app:get eurooffice DocumentServerUrl 2>/dev/null | grep -q "http"; do \
-	    printf "\r[nextcloud] installing  (%ds)   " $$(($$(date +%s) - start)); \
+	    if [ "$$(docker inspect --format '{{.State.Status}}' nextcloud 2>/dev/null)" != "running" ]; then \
+	      printf "\r[nextcloud] failed — check: docker compose logs nextcloud\n"; \
+	      exit 1; \
+	    fi; \
+	    elapsed=$$(($$(date +%s) - start)); \
+	    if [ $$elapsed -ge 1000 ]; then \
+	      last=$$(docker compose logs --tail=1 nextcloud 2>/dev/null | tr -d '\r'); \
+	      printf "\r[nextcloud] still installing (%ds) — %s   " $$elapsed "$$last"; \
+	    else \
+	      printf "\r[nextcloud] installing  (%ds)   " $$elapsed; \
+	    fi; \
 	    sleep 2; \
 	  done; \
 	  printf "\r[nextcloud] ready        (%ds)        \n" $$(($$(date +%s) - start))

--- a/develop/Makefile
+++ b/develop/Makefile
@@ -82,8 +82,29 @@ next:
 	@$(MAKE) --no-print-directory print-nc-version
 	@docker compose exec eo bash || true
 
+# Like `make next`, but injects the detected HOST_LAN_IP for Android emulator / LAN device testing.
+next-mobile:
+	@NC_BRANCH="$${NC_BRANCH:-master}" HOST_LAN_IP="$(DETECTED_HOST_LAN_IP)" $(MAKE) next
+
 pull:
 	docker compose pull && docker compose up -d && docker compose exec eo bash || true
+
+# Remove the Nextcloud data volume for the current NC_VERSION (default: latest).
+# Use this when you want a clean NC install, e.g. after a major version bump.
+#   make wipe-nc                  — wipes nc_data_latest
+#   make wipe-nc NC_VERSION=33    — wipes nc_data_33
+wipe-nc:
+	@docker compose stop nextcloud 2>/dev/null || true
+	@echo "Removing volume nc_data_$${NC_VERSION:-latest}..."
+	@docker volume rm nc_data_$${NC_VERSION:-latest} 2>/dev/null && echo "Done." || echo "Volume not found — nothing to remove."
+
+# Remove the Nextcloud data volume for the given NC_BRANCH (default: master).
+#   make wipe-next                      — wipes nc_data_master
+#   make wipe-next NC_BRANCH=stable33   — wipes nc_data_stable33
+wipe-next:
+	@docker compose stop nextcloud 2>/dev/null || true
+	@echo "Removing volume nc_data_$${NC_BRANCH:-master}..."
+	@docker volume rm nc_data_$${NC_BRANCH:-master} 2>/dev/null && echo "Done." || echo "Volume not found — nothing to remove."
 
 build:
 	(cd ../build && docker buildx bake develop) && \

--- a/develop/README.md
+++ b/develop/README.md
@@ -28,19 +28,26 @@ The docker compose environment in this directory allows to run document server b
         - Docs address `http://localhost:8080/`
         - Server address for internal requests from Euro-Office Docs `http://nextcloud/`
         - Docs address for internal requests from Nextcloud `http://eo/`
-        - Secret key: `secret`
+        - Secret key: `euro-office-dev-jwt-secret-key-2026`
     - Navigate to Files `http://localhost:8081/apps/files/`, create a document, and try to open it
 
 #### Testing from mobile devices and emulators
 
-`make local` runs on `localhost` — enough for the desktop browser and iOS simulator. For Android emulators and physical devices on the LAN, use `make mobile` instead — it detects the host's LAN IP and injects it so the editor is reachable from off-desktop clients.
+`make local` runs on `localhost` — enough for the desktop browser and iOS simulator. For Android emulators and physical devices on the LAN, use `make mobile` instead — it detects the host's LAN IP, injects it so the editor is reachable from off-desktop clients, and prints the full Nextcloud URL in the banner.
+
+For testing against a `make next` branch from a mobile device, use `make next-mobile` (accepts the same `NC_BRANCH` variable):
+
+```sh
+make next-mobile                        # mobile + NC master
+make next-mobile NC_BRANCH=stable34     # mobile + NC34 stable
+```
 
 | Client | Target | Nextcloud URL |
 |---|---|---|
 | Desktop browser | `make local` or `make mobile` | `http://localhost:8081/` |
 | iOS simulator | `make local` or `make mobile` | `http://localhost:8081/` |
-| Android emulator | `make mobile` | `http://10.0.2.2:8081/` |
-| Physical LAN device | `make mobile` | `http://<HOST_LAN_IP>:8081/` |
+| Android emulator | `make mobile` / `make next-mobile` | `http://10.0.2.2:8081/` |
+| Physical LAN device | `make mobile` / `make next-mobile` | `http://<HOST_LAN_IP>:8081/` |
 
 IP detection uses `ipconfig` on macOS and `ip route` on Linux. On native Windows — or any machine where detection fails — pass it explicitly:
 
@@ -54,11 +61,31 @@ When your LAN IP changes (new wifi, tethering, etc.), update the running stack w
 make refresh-urls
 ```
 
-Switching between `make local` and `make mobile` on a running stack is supported — both targets re-apply the correct URLs and trusted domains on each run.
+Switching between `make local` and `make mobile` (or `make next` and `make next-mobile`) on a running stack is supported — both targets re-apply the correct URLs and trusted domains on each run.
+
+#### Pinning the Nextcloud version
+
+`make local` follows `nextcloud:latest` from Docker Hub (current stable) and persists data in a named volume `nc_data_latest`. If `latest` advances to a newer NC major version, the NC entrypoint auto-runs `occ upgrade` on next start — no manual steps needed.
+
+To pin to a specific version, pass `NC_VERSION`:
+
+```sh
+NC_VERSION=33 make local    # pin to NC33, data in nc_data_33
+NC_VERSION=34 make local    # pin to NC34, data in nc_data_34
+```
+
+Each `NC_VERSION` gets its own named volume, so switching between pinned versions preserves each one's state.
+
+> Note: if your local `nextcloud:latest` image is behind the data volume (e.g. you pulled latest when it was NC33 but now the volume has NC34 data), `make` will detect this and print a pull command. This can happen if `docker pull nextcloud:latest` was not run after a major NC release.
+
+To wipe the data for the current version and start fresh:
+
+```sh
+make wipe-nc                  # wipes nc_data_latest
+make wipe-nc NC_VERSION=33    # wipes nc_data_33
+```
 
 #### Testing against a future Nextcloud version
-
-`make local` follows `nextcloud:latest` from Docker Hub — current stable.
 
 Use `make next` when you specifically need to test against an unreleased or non-current NC: `master`, `stable33`, `stable34`, etc.
 
@@ -72,7 +99,14 @@ make next NC_BRANCH=stable34        # NC34 stable (once cut)
 
 `make next` swaps the official image for the source-clone dev image (`nextcloud-docker-dev`) via `docker-compose.next.yml`, and gives each NC branch its own named volume — switching between branches preserves each branch's installed state (eurooffice config, files, sessions). Compose detects the volume mount change and recreates the container automatically; no manual stop/rm.
 
-First boot per branch will be several minutes while NC clones and installs into the empty volume; subsequent switches reattach to the warm volume in seconds. Wipe a single branch with `docker volume rm nc_data_<branch>`.
+First boot per branch will be several minutes while NC clones and installs into the empty volume; subsequent switches reattach to the warm volume in seconds. During a long first boot the banner shows a live log line after 1000s so you can confirm progress is still happening.
+
+Wipe a single branch with:
+
+```sh
+make wipe-next                        # wipes nc_data_master
+make wipe-next NC_BRANCH=stable33     # wipes nc_data_stable33
+```
 
 > Note: tracking `master` means NC's code moves between sessions. If you see `Nextcloud or one of the apps require upgrade` in `make next` output, run `docker compose exec -u www-data nextcloud ./occ upgrade` (or wipe the volume and then run `make next`).
 

--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - "8081:80"
     volumes:
-      - /var/www/html
+      - nc_data:/var/www/html
       - ./setup/enable-office.sh:/docker-entrypoint-hooks.d/post-installation/enable-office.sh:ro
       - ../../eurooffice-nextcloud:/var/www/html/custom_apps/eurooffice:ro
     environment:
@@ -48,4 +48,13 @@ services:
       ALLOW_PRIVATE_IP_ADDRESS: true
       USE_UNAUTHORIZED_STORAGE: true
       JWT_SECRET: ${EO_JWT_SECRET:-euro-office-dev-jwt-secret-key-2026}
+
+volumes:
+  nc_data:
+    # Per-version volume. NC_VERSION selects both the image tag and the volume,
+    # so each pinned version keeps its own state. Defaults to 'latest'.
+    # The NC entrypoint auto-runs occ upgrade when the image advances, so
+    # pulling a newer latest and restarting is safe — no manual upgrade needed.
+    # Wipe the current version's data with: make wipe-nc
+    name: nc_data_${NC_VERSION:-latest}
 


### PR DESCRIPTION
Make dev setup more robust and provide more useful feedback

Doesn't delete data volumes when switching to support different NC versions

Provides feedback if install is taking a long time

Provides feature to wipe targets

Adds `make next-mobile` - akin to `make next`