### PR TITLE
fix(wopi): ship document-formats for discovery

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 [submodule "sdkjs-forms"]
 	path = sdkjs-forms
 	url = https://github.com/Euro-Office/sdkjs-forms.git
+[submodule "document-formats"]
+	path = document-formats
+	url = https://github.com/Euro-Office/document-formats.git
+	branch = main

--- a/build/.docker/bundle.bake.Dockerfile
+++ b/build/.docker/bundle.bake.Dockerfile
@@ -27,6 +27,8 @@ FROM alpine AS bundle
     COPY dictionaries /build/documentserver/dictionaries
     COPY document-templates /build/documentserver/document-templates
     COPY core-fonts /build/documentserver/core-fonts
+    # WOPI/discovery format list consumed by services.CoAuthoring.server.documentFormatsFile
+    COPY document-formats/onlyoffice-docs-formats.json /build/documentserver/document-formats/onlyoffice-docs-formats.json
 
     # --- Config files
     COPY build/configs/core/DoctRenderer.config /build/documentserver/server/FileConverter/bin/DoctRenderer.config


### PR DESCRIPTION
WOPI `/hosting/discovery` (and `/meta/formats`) reference `<root>/document-formats/onlyoffice-docs-formats.json`, but nothing shipped it — so discovery listed no mimetypes.

- Add `document-formats` submodule (Euro-Office/document-formats)
- COPY its `onlyoffice-docs-formats.json` into the bundle, next to dictionaries/document-templates/core-fonts; the deb Makefile carries it into the package

Server-side fix that consumes the file: Euro-Office/server#26

Fixes #67 