### PR TITLE
fix: nginx latest security fix crashes editors, reverting

### DIFF
--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -26,6 +26,16 @@ ENV EO_CONF=${EO_CONF}
 ENV COMPANY_NAME_LOW=${COMPANY_NAME_LOW}
 ENV PRODUCT_NAME_LOW=${PRODUCT_NAME_LOW}
 
+
+#### Hotfix: nginx 1.24.0-2ubuntu7.10 broke editors, 
+#### switch back to 1.24.0-2ubuntu7.9 for now
+ARG APT_SNAPSHOT=20260602T120000Z
+RUN apt-get -y update && \
+    apt-get -yq install ca-certificates && \
+    sed -i '/^Suites:/a Snapshot: '"${APT_SNAPSHOT}" /etc/apt/sources.list.d/ubuntu.sources
+#### Hotfix
+
+
 RUN apt-get -y update && \
     ACCEPT_EULA=Y apt-get -yq install \
         postgresql postgresql-client redis-server rabbitmq-server \

--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -y update && \
 
 RUN ACCEPT_EULA=Y apt-get -yq install \
         postgresql postgresql-client redis-server rabbitmq-server \
-        nginx sudo gdb nginx-extras supervisor jq util-linux \
+        sudo gdb supervisor jq util-linux \
         netcat-openbsd xxd openssl && \
     rm -rf /var/lib/apt/lists/*
 

--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -32,12 +32,12 @@ ENV PRODUCT_NAME_LOW=${PRODUCT_NAME_LOW}
 ARG APT_SNAPSHOT=20260602T120000Z
 RUN apt-get -y update && \
     apt-get -yq install ca-certificates && \
-    echo "deb http://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT} noble main" \
-        > /etc/apt/sources.list.d/snapshot.list && \
+    printf "Types: deb\nURIs: http://snapshot.ubuntu.com/ubuntu/%s\nSuites: noble noble-updates noble-security\nComponents: main universe restricted multiverse\n" "${APT_SNAPSHOT}" \
+        > /etc/apt/sources.list.d/snapshot.sources && \
     apt-get -y update && \
-    apt-get -yq install nginx=1.24.0-2ubuntu7.9 nginx-extras=1.24.0-2ubuntu7.9 && \
+    apt-get -yq install --allow-downgrades nginx=1.24.0-2ubuntu7.9 nginx-extras=1.24.0-2ubuntu7.9 && \
     apt-mark hold nginx nginx-extras && \
-    rm /etc/apt/sources.list.d/snapshot.list && \
+    rm /etc/apt/sources.list.d/snapshot.sources && \
     apt-get -y update
 #### End hotfix
 

--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -32,12 +32,11 @@ ENV PRODUCT_NAME_LOW=${PRODUCT_NAME_LOW}
 ARG APT_SNAPSHOT=20260602T120000Z
 RUN apt-get -y update && \
     apt-get -yq install ca-certificates && \
-    printf "Types: deb\nURIs: http://snapshot.ubuntu.com/ubuntu/%s\nSuites: noble noble-updates noble-security\nComponents: main universe restricted multiverse\n" "${APT_SNAPSHOT}" \
-        > /etc/apt/sources.list.d/snapshot.sources && \
+    sed -i '/^Suites:/a Snapshot: '"${APT_SNAPSHOT}" /etc/apt/sources.list.d/ubuntu.sources && \
     apt-get -y update && \
     apt-get -yq install --allow-downgrades nginx=1.24.0-2ubuntu7.9 nginx-extras=1.24.0-2ubuntu7.9 && \
     apt-mark hold nginx nginx-extras && \
-    rm /etc/apt/sources.list.d/snapshot.sources && \
+    sed -i '/^Snapshot:/d' /etc/apt/sources.list.d/ubuntu.sources && \
     apt-get -y update
 #### End hotfix
 

--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -27,17 +27,22 @@ ENV COMPANY_NAME_LOW=${COMPANY_NAME_LOW}
 ENV PRODUCT_NAME_LOW=${PRODUCT_NAME_LOW}
 
 
-#### Hotfix: nginx 1.24.0-2ubuntu7.10 broke editors, 
-#### switch back to 1.24.0-2ubuntu7.9 for now
+#### Hotfix: nginx 1.24.0-2ubuntu7.10 broke editors,
+#### pin only nginx to 1.24.0-2ubuntu7.9 from the snapshot and hold it
 ARG APT_SNAPSHOT=20260602T120000Z
 RUN apt-get -y update && \
     apt-get -yq install ca-certificates && \
-    sed -i '/^Suites:/a Snapshot: '"${APT_SNAPSHOT}" /etc/apt/sources.list.d/ubuntu.sources
-#### Hotfix
+    echo "deb http://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT} noble main" \
+        > /etc/apt/sources.list.d/snapshot.list && \
+    apt-get -y update && \
+    apt-get -yq install nginx=1.24.0-2ubuntu7.9 nginx-extras=1.24.0-2ubuntu7.9 && \
+    apt-mark hold nginx nginx-extras && \
+    rm /etc/apt/sources.list.d/snapshot.list && \
+    apt-get -y update
+#### End hotfix
 
 
-RUN apt-get -y update && \
-    ACCEPT_EULA=Y apt-get -yq install \
+RUN ACCEPT_EULA=Y apt-get -yq install \
         postgresql postgresql-client redis-server rabbitmq-server \
         nginx sudo gdb nginx-extras supervisor jq util-linux \
         netcat-openbsd xxd openssl && \


### PR DESCRIPTION
a security update for Nginx (https://launchpad.net/ubuntu/+source/nginx/1.24.0-2ubuntu7.10) appears to be breaking the editors in Ubuntu 24.04; Nginx is constantly crashing. Reverting back to with https://launchpad.net/ubuntu/+source/nginx/1.24.0-2ubuntu7.9 via snapshot.