### PR TITLE
fix: properly tag final release builds

### DIFF
--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -27,7 +27,7 @@ PUSH=0
 usage() {
     echo "Usage: $0 [-b BUILD_NUMBER] [-p PRE_ID] [--dry-run] [--push]"
     echo ""
-    echo "Tags the main repo and all submodules with vVERSION[-PRE_ID].BUILD_NUMBER"
+    echo "Tags the main repo and all submodules with vVERSION[-PRE_ID]+BUILD_NUMBER"
     echo ""
     echo "Options:"
     echo "  -b, --build BUILD_NUMBER   Build number (default: last build + 1)"
@@ -66,11 +66,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Build the tag prefix. With a pre-release id it's "vX.Y.Z-ID.", without it "vX.Y.Z-".
+# Build the tag prefix. With a pre-release id it's "vX.Y.Z-ID+", without it "vX.Y.Z+".
+# Build metadata is separated by "+" per semver.org.
 if [ -n "$PRE_ID" ]; then
-    TAG_PREFIX="v${VERSION}-${PRE_ID}."
+    TAG_PREFIX="v${VERSION}-${PRE_ID}+"
 else
-    TAG_PREFIX="v${VERSION}-"
+    TAG_PREFIX="v${VERSION}+"
 fi
 
 if [ -z "$BUILD_NUMBER" ]; then

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-
 VERSION_FILE="$REPO_ROOT/VERSION"
+
 if [ ! -f "$VERSION_FILE" ]; then
     echo "ERROR: VERSION file not found at $VERSION_FILE"
     exit 1
@@ -21,17 +21,17 @@ fi
 # Parse arguments
 DRY_RUN=0
 BUILD_NUMBER=""
-PRE_ID="tp"
+PRE_ID=""
 PUSH=0
 
 usage() {
-    echo "Usage: $0 [-b BUILD_NUMBER] [--dry-run] [--push]"
+    echo "Usage: $0 [-b BUILD_NUMBER] [-p PRE_ID] [--dry-run] [--push]"
     echo ""
-    echo "Tags the main repo and all submodules with vVERSION-ID.BUILD_NUMBER"
+    echo "Tags the main repo and all submodules with vVERSION[-PRE_ID].BUILD_NUMBER"
     echo ""
     echo "Options:"
     echo "  -b, --build BUILD_NUMBER   Build number (default: last build + 1)"
-    echo "  -p, --pre-id ID            Pre-release identifier (default: tp)"
+    echo "  -p, --pre-id ID            Pre-release identifier (default: none)"
     echo "  --dry-run                  Print tags without creating them"
     echo "  --push                     Push tags to remote after creating"
     echo "  -h, --help                 Show this help"
@@ -66,10 +66,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Build the tag prefix. With a pre-release id it's "vX.Y.Z-ID.", without it "vX.Y.Z-".
+if [ -n "$PRE_ID" ]; then
+    TAG_PREFIX="v${VERSION}-${PRE_ID}."
+else
+    TAG_PREFIX="v${VERSION}-"
+fi
+
 if [ -z "$BUILD_NUMBER" ]; then
-    # Find the highest existing build number for this version
-    LAST_BUILD=$(git -C "$REPO_ROOT" tag --list "v${VERSION}-${PRE_ID}.*" \
-        | sed "s/^v${VERSION}-${PRE_ID}\.//" \
+    # Find the highest existing build number for this version/pre-id.
+    # The [0-9] in the glob keeps numeric builds only, so a "vX.Y.Z-" prefix
+    # won't accidentally pick up "vX.Y.Z-tp.N" style tags.
+    LAST_BUILD=$(git -C "$REPO_ROOT" tag --list "${TAG_PREFIX}[0-9]*" \
+        | sed "s|^${TAG_PREFIX}||" \
         | sort -n \
         | tail -1)
     if [ -z "$LAST_BUILD" ]; then
@@ -85,25 +94,22 @@ if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-TAG="v${VERSION}-${PRE_ID}.${BUILD_NUMBER}"
+TAG="${TAG_PREFIX}${BUILD_NUMBER}"
 
 tag_repo() {
     local repo_path="$1"
     local repo_name="$2"
     local tag="$3"
-
     if git -C "$repo_path" rev-parse "$tag" >/dev/null 2>&1; then
         echo "  SKIP $repo_name — tag $tag already exists"
         return 0
     fi
-
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "  [DRY RUN] Would tag $repo_name at $(git -C "$repo_path" rev-parse --short HEAD) as $tag"
     else
         git -C "$repo_path" tag -a "$tag" -m "Release $tag"
         echo "  Tagged $repo_name at $(git -C "$repo_path" rev-parse --short HEAD) as $tag"
     fi
-
     if [ "$PUSH" -eq 1 ] && [ "$DRY_RUN" -eq 0 ]; then
         git -C "$repo_path" push origin "$tag"
         echo "  Pushed $tag for $repo_name"


### PR DESCRIPTION
The tag_release.sh script was unable to create non-pre-release tags. This fix makes the --pre-id parameter optional. So if no pre-id is given it only adds the build number.

Example: Version: v9.3.1, build 5

- if "--pre-id tp", then it creates v9.3.1-tp.5
- if "--pre-id" is not provided, then it creates v9.3.1-5