### PR TITLE
docs: adopt AI contribution policy bindings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,80 @@
+## Build & run a test server (Docker)
+
+The dev environment in `develop/` runs a full document server from a prebuilt image. Individual components are rebuilt *inside* the container — never rebuild the docker image to test a change. The repo is bind-mounted at `/develop` in the container, so edits on the host are immediately visible inside.
+
+### Start the server
+
+```sh
+cd develop
+docker compose pull eo     # one-time; multi-arch (amd64/arm64)
+docker compose up -d eo    # document server only; add `nextcloud` for the connector flow
+```
+
+If the pull fails (GHCR auth), build locally once: `cd build && docker buildx bake develop`.
+
+Do not use `make`/`make local` in `develop/` — those exec into an interactive shell. Use `docker compose exec -T eo <cmd>` for everything.
+
+Wait until ready (returns `true`):
+
+```sh
+curl -sf http://localhost:8080/healthcheck
+```
+
+### Build changes
+
+Run targets from the in-container Makefile (mounted at `/Makefile`; default workdir is `/`). Each target builds the component from `/develop`, deploys it into the installed tree, and restarts the affected service:
+
+```sh
+docker compose exec -T eo make web-apps           # full web-apps build (installs npm deps; needed once first)
+docker compose exec -T eo make web-apps-dev       # fast rebuild, skips npm install/babel/imagemin
+docker compose exec -T eo make sdkjs              # closure compile + allfontsgen
+docker compose exec -T eo make core               # all of core; subsets: core/x2t, core/allfontsgen, ...
+docker compose exec -T eo make server/docservice  # also: server/converter, server/metrics, server/adminp
+```
+
+For changes spanning several submodules, run the targets back to back (e.g. `make sdkjs web-apps`). First run of each target installs npm deps and is slow; later runs are faster. Core builds are incremental (ninja) only for the lifetime of the container. `web-apps`/`sdkjs` targets flush the nginx cache tag automatically.
+
+Note: builds run against the bind-mounted checkout and can modify it — the web-apps targets run `translation/merge_and_check.py`, which rewrites locale JSON files in the working tree. Don't commit those changes unless intended.
+
+Troubleshooting: if `make` fails with `Makefile: No such file or directory`, the single-file bind mount of `develop/setup/Makefile` went stale (editing that file on the host replaces its inode). Fix with `docker compose up -d --force-recreate eo` — this also resets all in-container build/deploy state, so previously built components revert to the image's versions and need rebuilding.
+
+### Test the change
+
+- **Example app** (no Nextcloud needed): open `http://localhost:8080/example/` — create a document, spreadsheet, or presentation and open it in the editor. The welcome page is at `http://localhost:8080/`.
+- **Service status & logs**: `docker compose exec -T eo supervisorctl status`; logs live under `/var/log/euro-office/documentserver/` (e.g. `docservice/out.log`, `converter/out.log`, `ds-example_out.log`).
+- **Conversion check**: opening a `.docx`/`.xlsx` in the example app exercises FileConverter + x2t; watch `converter/out.log` for errors.
+- **Nextcloud connector flow** (only when testing the integration): `docker compose up -d`, then `make refresh-urls` to wait for install and wire URLs/JWT; Nextcloud at `http://localhost:8081/` (admin/admin).
+
+## Commits
+
+- Commit messages must follow the Conventional Commits v1.0.0 specification — e.g. feat(chat): add voice message playback, fix(call): handle MCU disconnect gracefully.
+- Every commit containing AI-assisted content must include an `Assisted-by:` trailer identifying the coding agent and the model(s) used:
+    Pattern: Assisted-by: AGENT_NAME:MODEL_VERSION (e.g. Assisted-by: ClaudeCode:claude-opus-4-8)
+    Add one `Assisted-by:` line per agent/model if more than one was used.
+
+## Contribution policy
+
+All contributions generated or assisted by this agent must fully comply with:
+
+- **[AI Contribution Policy](https://github.com/Euro-Office/.github/blob/main/AI_POLICY.md)** — the primary reference for AI-specific rules, covering disclosure, author accountability, communication, security, licensing, code quality, and autonomous agent behavior.
+- **[Contribution Guidelines](CONTRIBUTING.md)** — covering testing requirements, sign-off, license headers, and the review process. These apply in full to all contributions regardless of how they were produced.
+
+### What this agent must always do
+
+- Add an `Assisted-by: AGENT_NAME:MODEL_VERSION` git trailer to every commit containing AI-assisted content.
+- Ensure every pull request includes a disclosure of AI tool use in the PR description.
+- Produce focused, scoped pull requests that address exactly one concern. Do not touch unrelated files or introduce incidental refactors.
+- Verify all dependencies against actual package registries before suggesting them. Do not use hallucinated or unverified package names.
+- Explicitly inform the contributor when any action they are about to take, or have taken, would violate the AI Contribution Policy or the Contribution Guidelines. Do not silently proceed. State which rule is at risk and what the contributor should do instead.
+- Warn the contributor if a pull request is growing too large. A PR approaching several thousand lines of changed code is a signal that it should be split into smaller, focused PRs. Suggest a logical split before the PR is opened, not after.
+- Recommend opening a ticket for discussion before starting implementation whenever a feature or change is sufficiently complex — for example when it touches multiple subsystems, requires architectural decisions, or the right approach is not yet clear.
+
+### What this agent must never do
+
+- Open issues, submit pull requests, post review comments, or send security reports autonomously. Every contribution must be reviewed and submitted by a human.
+- Add `Signed-off-by` tags to commits. Only the human contributor can certify the Developer Certificate of Origin.
+- Generate or submit security reports without independent human verification. Report verified vulnerabilities privately by email to the maintainers (`euro-office-team` on the `proton.me` mail server), not as GitHub issues.
+- Write PR descriptions, review comments, or issue reports on behalf of the contributor. These must be in the contributor's own words.
+- Fully automate the resolution of issues labeled [`good first issue`](https://github.com/search?q=org%3AEuro-Office+label%3A%22good+first+issue%22&type=issues) or similar beginner-friendly labels.
+- Submit code that has not been reviewed and cleaned up by the contributor. Dead code, redundant logic, excessive comments, and unrelated changes must be removed before submission.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,18 @@ A PR should:
 * Contributions should align with:
   * Existing architecture
   * Project roadmap (where applicable)
+
+## AI-assisted contributions
+
+Euro-Office allows contributions made with the help of AI tools. You are the author of everything you submit — AI assistance does not change that responsibility.
+
+* **Disclosure:** Declare AI tool use in the PR description and add an `Assisted-by: AGENT_NAME:MODEL_VERSION` git trailer to each affected commit.
+* **Accountability:** You must be able to explain, defend, and modify every line you submit. If a reviewer asks why something works a certain way, "the AI wrote it" is not an answer.
+* **Communication:** PR descriptions, review comments, and issue reports must be written in your own words. This applies throughout the review process — passing reviewer feedback to an AI and posting whatever comes out is not acceptable.
+* **Quality:** AI output must be reviewed, cleaned up, and tested by you before submission. New features must be tested on a live instance by you, not by an agent. Code that has never been executed, or that shifts debugging work onto maintainers, will not be accepted.
+* **Licensing:** Ensure AI-generated code contains no material incompatible with the AGPLv3 or the license of any third-party component you are contributing to.
+* **Sign-off:** Only the human contributor may add the `Signed-off-by` trailer. An agent must never sign off on your behalf.
+
+For the full policy including autonomous agent rules, security reports, and beginner issues, read the [AI Contribution Policy][aipolicy].
+
+[aipolicy]: https://github.com/Euro-Office/.github/blob/main/AI_POLICY.md


### PR DESCRIPTION
Adapts the repo-targeted parts of Euro-Office/.github#16 into this repository.

- **AGENTS.md** — binds agents to the [AI Contribution Policy](https://github.com/Euro-Office/.github/blob/main/AI_POLICY.md) with must-do / must-never lists, and standardizes the commit trailer on `Assisted-by: AGENT_NAME:MODEL_VERSION` (was `AI-assistant:`).
- **CONTRIBUTING.md** — adds an *AI-assisted contributions* section (disclosure, accountability, communication, quality, licensing, sign-off) linking to the org policy. This file is the "DocumentServer Contribution Guidelines" the org-wide CONTRIBUTING.md points to.

The full `AI_POLICY.md` is not copied here; it stays canonical in the org `.github` repo and is linked by URL.

> Note for review: the must-never list states an agent should never add `Signed-off-by`. This tension with maintainer auto-signoff workflows is worth a conscious decision before merge.

AI assistance was used to draft these changes; see the `Assisted-by:` commit trailer.