### PR TITLE
Fix WOPI proof key signing failure

### DIFF
--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -143,7 +143,7 @@ if [ "$WOPI_ENABLED" = "true" ]; then
   fi
   WOPI_MODULUS=$(openssl rsa -pubin -inform "MS PUBLICKEYBLOB" -modulus -noout -in "$WOPI_PUBLIC_KEY" | sed 's/Modulus=//' | xxd -r -p | openssl base64 -A)
   WOPI_EXPONENT=$(openssl rsa -pubin -inform "MS PUBLICKEYBLOB" -text -noout -in "$WOPI_PUBLIC_KEY" | grep -oP '(?<=Exponent: )\d+')
-  WOPI_PRIVATE_KEY_DATA=$(awk '{printf "%s\\n", $0}' "$WOPI_PRIVATE_KEY")
+  WOPI_PRIVATE_KEY_DATA=$(cat "$WOPI_PRIVATE_KEY")
   WOPI_PUBLIC_KEY_DATA=$(openssl base64 -in "$WOPI_PUBLIC_KEY" -A)
 fi
 


### PR DESCRIPTION
## Summary

The `awk` command on line 146 of `entrypoint.sh` flattens the PEM private key by replacing real newlines with literal `\n` characters:

```sh
WOPI_PRIVATE_KEY_DATA=$(awk '{printf %s\\n, $0}' $WOPI_PRIVATE_KEY)
```

When `jq --arg` receives this, it treats `\n` as literal text and escapes it again. The resulting key in `local.json` has no real newlines, which OpenSSL cannot decode:

```
error:1E08010C:DECODER routines::unsupported
    at signOneShot (node:internal/crypto/sig:169:15)
    at generateProofSign (/snapshot/server/DocService/sources/wopiUtils.js)
```

This breaks any WOPI integration that requires proof key verification. Tested on both x86_64 and ARM64.

## Fix

Replace `awk` with `cat` so `jq --arg` receives the raw PEM with real newlines and encodes them correctly in JSON.

One line change. Credit to @tiran133 for identifying the fix in #127.

## How I found this

I built an integration of Euro-Office with ownCloud OCIS ([repo](https://github.com/delmarguillen/euro-office-ocis)). The WOPI `checkFileInfo` call failed on every document open.

## Tested on

- DocumentServer 9.3.1 Build 37 (`ghcr.io/euro-office/documentserver:latest`)
- VPS: x86_64, Ubuntu 24.04, Docker 29.5.3
- Local: ARM64 (Surface Pro 9, Podman 5.8.3, WSL2)