### PR TITLE
feat(develop): parallel test servers via eo.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,24 @@ Troubleshooting: if `make` fails with `Makefile: No such file or directory`, the
 - **Conversion check**: opening a `.docx`/`.xlsx` in the example app exercises FileConverter + x2t; watch `converter/out.log` for errors.
 - **Nextcloud connector flow** (only when testing the integration): `docker compose up -d`, then `make refresh-urls` to wait for install and wire URLs/JWT; Nextcloud at `http://localhost:8081/` (admin/admin).
 
+### Running instances (`eo.sh`)
+
+`develop/eo.sh` runs one or more test servers as self-contained containers from the same image — current tree mounted at `/develop`, auto-assigned port. Starts detached (agent-friendly, unlike `make local`):
+
+```sh
+cd develop
+./eo.sh up <name>                  # start; waits for /healthcheck; prints URL + per-type editor URLs
+./eo.sh build <name> web-apps-dev  # in-container make targets (sdkjs, core/x2t, server/docservice, …)
+./eo.sh exec <name> <cmd…>         # run inside (TTY-aware)
+./eo.sh ls | logs <name> | down <name>|--all   # manage; `up --force` to recreate
+```
+
+Run a building instance from its own git worktree so builds don't share `node_modules`; a fresh worktree needs `git submodule update --init --recursive` first. JWT (secret `euro-office-dev-jwt-secret-key-2026`), `EXAMPLE_ENABLED` and `WOPI_ENABLED` are on, so the example app works out of the box.
+
+### Verify in a browser (Playwright MCP)
+
+Don't trust HTTP 200 — the editor shell can load while the document download fails. `browser_navigate` to a create-new URL (`…/example/editor?fileExt=docx|xlsx|pptx|pdf`; `?fileName=` expects an existing file and fails), `browser_wait_for` a few seconds, then `browser_snapshot`/`browser_take_screenshot` to confirm the toolbar and page render with no error dialog, plus `browser_console_messages` at level `error`. If it won't open, check `ds-example_out.log` (JWT) and `converter/out.log` (download 403) — usually a JWT secret mismatch.
+
 ## Commits
 
 - Commit messages must follow the Conventional Commits v1.0.0 specification — e.g. feat(chat): add voice message playback, fix(call): handle MCU disconnect gracefully.

--- a/develop/README.md
+++ b/develop/README.md
@@ -12,12 +12,16 @@ Before starting, make sure Docker and your build user are set up: [Build Requisi
   cd ../DocumentServer/develop
   ```
 - Follow the repo cloning steps in the build readme
-- In DocumentServer/develop, start the containers and get into eo bash with either: 
-  - `make` to use the image that is currently available locally
-  - `make pull` to use the latest image from github
-  - `make build` to build the image locally from scratch
+- In DocumentServer/develop, start the containers and get into eo bash. The
+  recommended path on all architectures is to **pull the prebuilt dev image** — a
+  multi-arch `:latest-dev` (amd64 **and** arm64) is published on every merge to `main`,
+  so no local image build is needed, including on Apple Silicon:
+  - `make pull` to pull the latest dev image from GitHub and start (recommended first step)
+  - `make` to use the image already available locally
+  - `make build` to build the dev image locally from scratch — only needed for offline
+    work or when changing the image/toolchain itself (this is the long, full build)
   - `make mobile` for Android emulator / physical LAN device testing (see below)
-  
+
   You may need to generate a PAT first, as described in https://github.com/Euro-Office/DocumentServer/pkgs/container/documentserver
 - In docker-compose.yml, for the eo service, ensure that `target` is set to `develop`
 
@@ -154,7 +158,42 @@ The Docker image and dev Makefile handle ARM64 automatically:
 - **web-apps**: Skips imagemin on arm64 (native binaries are x86_64-only)
 - **server**: `pkg` builds native arm64 binaries
 
-No GHCR arm64 image is available yet, so ARM64 users must build locally with `make build`.
+A multi-arch `:latest-dev` image (amd64 + arm64) is published to GHCR on every merge to `main`, so ARM64 users can `make pull` like everyone else — `make build` is only needed for offline work or to rebuild the image itself.
+
+## Parallel test servers (`eo.sh`)
+
+The `make` workflow above runs a single Nextcloud-integrated stack with fixed
+container names and ports — use it for interactive, integration-style testing.
+
+When you instead need **several throwaway document servers at once** — e.g. a coding
+agent spinning one up per branch/worktree to verify a change and run build steps —
+use `./eo.sh`. Each instance is a single, fully self-contained container (its own
+Postgres, Redis, RabbitMQ, Nginx, supervisord) from the same `:latest-dev` image, so
+there is no shared state and no full build:
+
+```sh
+./eo.sh up <name> [port]        # start eo-<name>; auto host port if omitted; waits for /healthcheck, prints URL
+./eo.sh build <name> <target>   # run an in-container make target: web-apps-dev | sdkjs | server/docservice | core/x2t | …
+./eo.sh exec <name> [cmd…]      # shell (default) or command inside the container
+./eo.sh logs <name>             # follow logs
+./eo.sh ls                      # list running instances with host ports
+./eo.sh down <name>… | --all    # stop and remove instance(s)
+```
+
+Each instance mounts the **current git working tree** at `/develop`, so the build
+targets operate on your local changes. Run each *building* instance from its own git
+worktree so parallel builds don't share (and clobber) `node_modules`.
+
+Instances start with `EXAMPLE_ENABLED=true` (test editor at `/example/`) and
+`WOPI_ENABLED=true`. JWT is **enabled** with a shared dev secret
+(`EO_JWT_SECRET`, default `euro-office-dev-jwt-secret-key-2026`) — the bundled example
+app always requires JWT, so this is what lets documents actually open. These are local
+test servers — **do not expose them publicly**. Override the image with `EO_IMAGE=…`
+(must be a `-dev` image; the production `:latest` lacks the build toolchain).
+
+To create and open a document, use the example app's **Create new → Document** (which
+hits `editor?fileExt=docx`). Opening `editor?fileName=new.docx` directly will fail —
+that form expects an already-existing file.
 
 ## Development Builds
 

--- a/develop/eo.sh
+++ b/develop/eo.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# eo.sh — run multiple isolated Euro-Office test servers in parallel.
+#
+# Each instance is a single self-contained container (its own Postgres, Redis,
+# RabbitMQ, Nginx and supervisord) built from the prebuilt multi-arch dev image
+# ghcr.io/euro-office/documentserver:latest-dev. No full docker build required.
+#
+# The current git working tree is mounted at /develop so the in-container `make`
+# targets (web-apps-dev, sdkjs, server/docservice, core/x2t, …) rebuild your
+# local changes in place. Run each building instance from its own worktree so
+# parallel builds don't clobber each other's node_modules.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+EO_IMAGE="${EO_IMAGE:-ghcr.io/euro-office/documentserver:latest-dev}"
+# Shared, predictable JWT secret. The bundled example app always runs with JWT
+# enabled, so the document server must sign its requests with the same secret —
+# otherwise /download is rejected (403) and documents won't open. Override via env.
+EO_JWT_SECRET="${EO_JWT_SECRET:-euro-office-dev-jwt-secret-key-2026}"
+LABEL="eo.test=1"
+PREFIX="eo-"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+cname() { printf '%s%s' "$PREFIX" "$1"; }
+
+# Docker container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*.
+valid_name() { [[ "$1" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]]; }
+
+repo_root() {
+  git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null \
+    || die "not inside a git repository (run from within the DocumentServer checkout)"
+}
+
+host_port() {
+  # Resolve the host port mapped to container :80 (handles 0.0.0.0:PORT / [::]:PORT).
+  docker port "$(cname "$1")" 80 2>/dev/null | head -n1 | sed 's/.*://'
+}
+
+require_name() { [ -n "${1:-}" ] || die "$2"; }
+
+ensure_exists() {
+  docker inspect "$(cname "$1")" >/dev/null 2>&1 || die "no such instance '$1' (see: eo.sh ls)"
+}
+
+ensure_running() {
+  ensure_exists "$1"
+  [ "$(docker inspect -f '{{.State.Status}}' "$(cname "$1")" 2>/dev/null)" = "running" ] \
+    || die "instance '$1' is not running (see: eo.sh ls)"
+}
+
+# Host path bind-mounted to /develop in the given container (empty if none).
+mount_src() {
+  docker inspect -f '{{range .Mounts}}{{if eq .Destination "/develop"}}{{.Source}}{{end}}{{end}}' "$1" 2>/dev/null
+}
+
+cmd_up() {
+  local force=0
+  if [ "${1:-}" = "-f" ] || [ "${1:-}" = "--force" ]; then force=1; shift; fi
+  local name="${1:-}" port="${2:-}"
+  require_name "$name" "usage: eo.sh up [--force] <name> [port]"
+  valid_name "$name" || die "invalid name '$name' (allowed: letters, digits, '_', '.', '-')"
+  [ -z "$port" ] || [[ "$port" =~ ^[0-9]+$ ]] || die "port must be numeric, got '$port'"
+  local container; container="$(cname "$name")"
+
+  if docker inspect "$container" >/dev/null 2>&1; then
+    if [ "$force" -eq 1 ]; then
+      echo "Recreating $container (--force)"
+      docker rm -f "$container" >/dev/null
+    else
+      die "instance '$name' already exists (use 'eo.sh up --force $name' to recreate, or 'eo.sh down $name')"
+    fi
+  fi
+
+  local publish
+  if [ -n "$port" ]; then publish="${port}:80"; else publish="0:80"; fi
+
+  local root; root="$(repo_root)"
+  echo "Starting $container from $EO_IMAGE"
+  echo "  mount: $root -> /develop"
+  # A fresh `git worktree` doesn't populate submodules; warn before in-container
+  # builds fail confusingly on an empty source tree.
+  [ -d "$root/web-apps/build" ] || \
+    echo "  warning: $root/web-apps looks uninitialized — run 'git submodule update --init --recursive' here before 'eo.sh build'" >&2
+
+  if ! docker run -d \
+    --name "$container" \
+    --label "$LABEL" \
+    -p "$publish" \
+    -e EXAMPLE_ENABLED=true \
+    -e WOPI_ENABLED=true \
+    -e JWT_SECRET="$EO_JWT_SECRET" \
+    -e USE_UNAUTHORIZED_STORAGE=true \
+    -e ALLOW_PRIVATE_IP_ADDRESS=true \
+    -e THEME=euro-office \
+    -v "$root:/develop" \
+    -v "$SCRIPT_DIR/setup/Makefile:/Makefile" \
+    "$EO_IMAGE" >/dev/null; then
+    # Failed start (e.g. port already allocated) leaves a Created container that
+    # would block the next 'up' — remove it so re-running is clean.
+    docker rm -f "$container" >/dev/null 2>&1 || true
+    die "failed to start $container (is the port in use?)"
+  fi
+
+  printf 'Waiting for %s to become healthy' "$container"
+  local _
+  for _ in $(seq 1 150); do
+    if docker exec "$container" curl -sf http://localhost/healthcheck >/dev/null 2>&1; then
+      local hp; hp="$(host_port "$name")"
+      echo " ready"
+      echo
+      local base="http://localhost:${hp}"
+      echo "  $container  ->  ${base}/"
+      echo "  example app ->  ${base}/example/"
+      echo "  new document     ${base}/example/editor?fileExt=docx"
+      echo "  new spreadsheet  ${base}/example/editor?fileExt=xlsx"
+      echo "  new presentation ${base}/example/editor?fileExt=pptx"
+      echo "  new pdf form     ${base}/example/editor?fileExt=pdf"
+      echo
+      echo "  build:  ./eo.sh build $name web-apps-dev"
+      echo "  shell:  ./eo.sh exec  $name"
+      echo "  stop:   ./eo.sh down  $name"
+      return 0
+    fi
+    if [ "$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)" != "running" ]; then
+      echo " failed"
+      die "container exited — check: ./eo.sh logs $name"
+    fi
+    printf '.'
+    sleep 2
+  done
+  echo " timeout"
+  die "healthcheck did not pass — check: ./eo.sh logs $name"
+}
+
+cmd_build() {
+  local name="${1:-}"; shift || true
+  require_name "$name" "usage: eo.sh build <name> <make-target> [more targets…]"
+  [ "$#" -gt 0 ] || die "usage: eo.sh build <name> <make-target> [more targets…]"
+  ensure_running "$name"
+  docker exec "$(cname "$name")" make "$@"
+}
+
+cmd_exec() {
+  local name="${1:-}"; shift || true
+  require_name "$name" "usage: eo.sh exec <name> [command…]"
+  ensure_running "$name"
+  # Allocate a TTY only when attached to one, so non-interactive callers
+  # (agents, pipes) don't hit "the input device is not a TTY".
+  local flags=(-i); [ -t 0 ] && [ -t 1 ] && flags=(-i -t)
+  if [ "$#" -eq 0 ]; then
+    docker exec "${flags[@]}" "$(cname "$name")" bash
+  else
+    docker exec "${flags[@]}" "$(cname "$name")" "$@"
+  fi
+}
+
+cmd_logs() {
+  local name="${1:-}"
+  require_name "$name" "usage: eo.sh logs <name>"
+  ensure_exists "$name"
+  docker logs -f "$(cname "$name")"
+}
+
+cmd_ls() {
+  # -a so stopped/half-started instances are visible (they still block 'up').
+  local ids; ids="$(docker ps -aq --filter "label=$LABEL")"
+  if [ -z "$ids" ]; then echo "no eo.test instances"; return 0; fi
+  printf '%-16s %-9s %-7s %-26s %s\n' "INSTANCE" "STATUS" "PORT" "URL" "MOUNT"
+  local id name status hp url mnt
+  for id in $ids; do
+    name="$(docker inspect -f '{{.Name}}' "$id" | sed "s|^/${PREFIX}||")"
+    status="$(docker inspect -f '{{.State.Status}}' "$id")"
+    mnt="$(mount_src "$id")"; [ -n "$mnt" ] || mnt="-"
+    if [ "$status" = "running" ]; then
+      hp="$(host_port "$name")"; url="http://localhost:${hp}/"
+    else
+      hp="-"; url="-"
+    fi
+    printf '%-16s %-9s %-7s %-26s %s\n' "$name" "$status" "$hp" "$url" "$mnt"
+  done
+}
+
+cmd_down() {
+  [ "$#" -gt 0 ] || die "usage: eo.sh down <name>... | --all"
+  if [ "$1" = "--all" ]; then
+    local ids; ids="$(docker ps -aq --filter "label=$LABEL")"
+    if [ -n "$ids" ]; then
+      echo "$ids" | xargs docker rm -f >/dev/null && echo "removed all eo.test instances"
+    else
+      echo "nothing to remove"
+    fi
+    return 0
+  fi
+  local name
+  for name in "$@"; do
+    docker rm -f "$(cname "$name")" >/dev/null && echo "removed $(cname "$name")"
+  done
+}
+
+usage() {
+  cat <<'EOF'
+eo.sh — run multiple isolated Euro-Office test servers in parallel.
+
+Usage:
+  eo.sh up [--force] <name> [port]
+                                Start instance eo-<name>. Auto-assigns a free host
+                                port unless one is given. Waits for /healthcheck,
+                                then prints the URL. --force recreates an existing one.
+  eo.sh build <name> <target>   Run an in-container make target against the mounted
+                                source, e.g.: web-apps-dev | sdkjs | server/docservice
+                                | server/converter | core/x2t | core/docbuilder
+  eo.sh exec <name> [cmd…]      Run a command (default: bash) inside the container.
+  eo.sh logs <name>             Follow container logs.
+  eo.sh ls                      List running instances with their host ports.
+  eo.sh down <name>… | --all    Stop and remove instance(s).
+
+Env:
+  EO_IMAGE        Override the image (default ghcr.io/euro-office/documentserver:latest-dev).
+                  Must be a *-dev image — the production :latest lacks the build toolchain.
+  EO_JWT_SECRET   Shared JWT secret for the document server and the bundled example app
+                  (default: euro-office-dev-jwt-secret-key-2026). Use this when signing
+                  API requests directly.
+
+Notes:
+  - The current git working tree is mounted at /develop. Run each *building* instance
+    from its own git worktree so parallel builds don't share node_modules.
+  - JWT is ENABLED with a shared dev secret so the example app's /download works and
+    documents open. These are local test servers — do not expose them publicly.
+    EXAMPLE_ENABLED and WOPI_ENABLED are on by default.
+EOF
+}
+
+main() {
+  command -v docker >/dev/null 2>&1 || die "docker not found in PATH"
+  local sub="${1:-}"; shift || true
+  case "$sub" in
+    up)    cmd_up    "$@" ;;
+    build) cmd_build "$@" ;;
+    exec)  cmd_exec  "$@" ;;
+    logs)  cmd_logs  "$@" ;;
+    ls)    cmd_ls    "$@" ;;
+    down)  cmd_down  "$@" ;;
+    ""|-h|--help|help) usage ;;
+    *) die "unknown command '$sub' (see: eo.sh --help)" ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Adds `develop/eo.sh` to run multiple isolated DocumentServer test instances in parallel from the prebuilt multi-arch `:latest-dev` image, no full docker build required. Useful for quickly verifying submodule changes (incl. by coding agents) and for testing several branches/worktrees at once.

Each instance is a single self-contained container (its own Postgres/Redis/RabbitMQ/Nginx/supervisord) that mounts the current git working tree at `/develop`, so the existing in-container `make` targets rebuild local changes in place.

```
eo.sh up [--force] <name> [port]   # start; auto host port; waits for /healthcheck; prints URLs
eo.sh build <name> <make-target>   # web-apps-dev | sdkjs | server/docservice | core/x2t | …
eo.sh exec <name> [cmd…]           # shell/command inside (TTY-aware)
eo.sh logs <name>                  # follow logs
eo.sh ls                           # instances with status, port, URL, mount path
eo.sh down <name>… | --all         # stop & remove
```

Instances run with JWT enabled (shared dev secret), `EXAMPLE_ENABLED` and `WOPI_ENABLED`, so the bundled example app works and documents open. `up` prints create-new editor URLs for all document types.

Also corrects a stale `develop/README.md` note (a multi-arch `:latest-dev` incl. arm64 is published, so `make pull` works on Apple Silicon) and documents the new workflow.

## Verification
- Multiple instances run concurrently on distinct auto-assigned ports; healthchecks pass; example editor opens a document end-to-end.
- `eo.sh build … web-apps-dev` runs a real in-container build and reloads nginx.
- `bash -n` + shellcheck clean; kept bash 3.2 compatible (macOS system bash).