### PR TITLE
fix(docker): give ds services a writable HOME so sharp can load

### DIFF
--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -59,6 +59,13 @@ RUN apt-get -y update && \
 COPY build/configs/standalone/supervisor/ /etc/supervisor/conf.d/
 COPY --chmod=755 build/scripts/standalone/entrypoint.sh /entrypoint.sh
 
+# Give the 'ds' service user a writable HOME. supervisord runs as root and does
+# not reset HOME when dropping to user=ds, so without this the node services
+# inherit HOME=/root and fail to write their cache (e.g. sharp/pkg extracting
+# native modules to ~/.cache), disabling image processing. HOME is set per
+# program in the supervisor confs; this just ensures the directory exists.
+RUN mkdir -p /home/ds && chown ds:ds /home/ds
+
 #RUN mkdir -p ${EO_LOG}/docservice ${EO_LOG}/converter \
 #             ${EO_LOG}/adminpanel ${EO_LOG}/metrics
 

--- a/build/configs/standalone/supervisor/ds-adminpanel.conf
+++ b/build/configs/standalone/supervisor/ds-adminpanel.conf
@@ -2,7 +2,7 @@
 command=%(ENV_EO_ROOT)s/server/AdminPanel/server/adminpanel
 directory=%(ENV_EO_ROOT)s/server/AdminPanel
 user=ds
-environment=NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
+environment=HOME=/home/ds,NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
 stdout_logfile=%(ENV_EO_LOG)s/adminpanel/out.log
 stdout_logfile_backups=0
 stdout_logfile_maxbytes=0

--- a/build/configs/standalone/supervisor/ds-converter.conf
+++ b/build/configs/standalone/supervisor/ds-converter.conf
@@ -2,7 +2,7 @@
 command=%(ENV_EO_ROOT)s/server/FileConverter/converter
 directory=%(ENV_EO_ROOT)s/server/FileConverter
 user=ds
-environment=NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
+environment=HOME=/home/ds,NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
 stdout_logfile=%(ENV_EO_LOG)s/converter/out.log
 stdout_logfile_backups=0
 stdout_logfile_maxbytes=0

--- a/build/configs/standalone/supervisor/ds-docservice.conf
+++ b/build/configs/standalone/supervisor/ds-docservice.conf
@@ -2,7 +2,7 @@
 command=%(ENV_EO_ROOT)s/server/DocService/docservice
 directory=%(ENV_EO_ROOT)s/server/DocService
 user=ds
-environment=NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
+environment=HOME=/home/ds,NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
 stdout_logfile=%(ENV_EO_LOG)s/docservice/out.log
 stdout_logfile_backups=0
 stdout_logfile_maxbytes=0

--- a/build/configs/standalone/supervisor/ds-example.conf
+++ b/build/configs/standalone/supervisor/ds-example.conf
@@ -2,7 +2,7 @@
 command=%(ENV_EO_ROOT)s-example/example
 directory=%(ENV_EO_ROOT)s-example/
 user=ds
-environment=NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s-example,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice
+environment=HOME=/home/ds,NODE_ENV=production-linux,NODE_CONFIG_DIR=%(ENV_EO_CONF)s-example,NODE_DISABLE_COLORS=1,APPLICATION_NAME=onlyoffice
 stdout_logfile=%(ENV_EO_LOG)s/ds-example_out.log
 stdout_logfile_backups=0
 stdout_logfile_maxbytes=0

--- a/build/configs/standalone/supervisor/ds-metrics.conf
+++ b/build/configs/standalone/supervisor/ds-metrics.conf
@@ -2,7 +2,7 @@
 command=%(ENV_EO_ROOT)s/server/Metrics/metrics ./config/config.js
 directory=%(ENV_EO_ROOT)s/server/Metrics
 user=ds
-environment=NODE_DISABLE_COLORS=1,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
+environment=HOME=/home/ds,NODE_DISABLE_COLORS=1,LD_LIBRARY_PATH=%(ENV_EO_ROOT)s/server/FileConverter/bin:%(ENV_EO_ROOT)s/server/FileConverter/lib
 stdout_logfile=%(ENV_EO_LOG)s/metrics/out.log
 stdout_logfile_backups=0
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Set `HOME=/home/ds` for all `ds`-owned supervisor programs and create the directory in the standalone image.

## Why

`supervisord` runs as root and does not reset `HOME` when dropping to `user=ds`, so the node services inherited `HOME=/root` and could not write their cache. sharp/pkg failed to extract its native module to `/root/.cache` (`EACCES`), which disabled image processing (`processImageOptimal` returned the original buffer).

## Test

In a running standalone container, apply the same `HOME` env to `ds-docservice`/`ds-converter`, `mkdir -p /home/ds && chown ds:ds /home/ds`, restart the services, open a document containing images, and confirm the `Sharp module failed to load` / `processImageOptimal: Sharp module not available` warnings no longer appear in `docservice/out.log`.

---
AI disclosure: changes drafted with AI assistance (ClaudeCode, model claude-opus-4-8); see the `Assisted-by` commit trailer. Please review before merging.