### PR TITLE
Run supervisord under tini to silence "reaped unknown pid" log noise

### DIFF
--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get -y update && \
     ACCEPT_EULA=Y apt-get -yq install \
         postgresql postgresql-client redis-server rabbitmq-server \
         nginx sudo gdb nginx-extras supervisor jq util-linux \
-        netcat-openbsd xxd openssl && \
+        netcat-openbsd xxd openssl tini && \
     rm -rf /var/lib/apt/lists/*
 
 # Create the 'ds' user that is required by OnlyOffice scripts

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -448,4 +448,9 @@ fi
 # --------------------------------------------------------------------
 [ -n "$JWT_MESSAGE" ] && echo "$JWT_MESSAGE"
 
-exec /usr/bin/supervisord
+# Hand off to supervisord under tini. tini becomes PID 1 and acts as the init
+# zombie-reaper: it silently reaps orphaned children of the bundled daemons
+# (postgres, redis, nginx, rabbitmq) and of the node services. Without it,
+# supervisord would run as PID 1 and log every reaped orphan as a noisy
+# "reaped unknown pid" INFO message.
+exec /usr/bin/tini -- /usr/bin/supervisord


### PR DESCRIPTION
Supervisord runs as PID 1 in the standalone image, so it reaps orphaned children of the bundled daemons and logs each one as a noisy `reaped unknown pid` INFO message. Run supervisord under `tini` so tini becomes PID 1 and reaps zombies silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173rJtqsWsbrFLRE5cgNssm

---
_Generated by [Claude Code](https://claude.ai/code/session_0173rJtqsWsbrFLRE5cgNssm)_