### PR TITLE
feat: raise maxDownloadBytes and inputLimits to 500MB, add runtime env vars (#210)

### DIFF
--- a/build/scripts/orchestrated/docker-entrypoint.sh
+++ b/build/scripts/orchestrated/docker-entrypoint.sh
@@ -184,6 +184,13 @@ export NODE_CONFIG='{
   "FileConverter": {
     "converter": {
         "maxprocesscount": 0.001,
+        "maxDownloadBytes": '${FILECONVERTER_MAX_DOWNLOAD_BYTES:-524288000}',
+        "inputLimits": [
+          { "type": "docx;dotx;docm;dotm", "zip": { "uncompressed": "'${FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED:-500MB}'", "template": "*.xml" } },
+          { "type": "xlsx;xltx;xlsm;xltm", "zip": { "uncompressed": "'${FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED:-500MB}'", "template": "*.xml" } },
+          { "type": "pptx;ppsx;potx;pptm;ppsm;potm", "zip": { "uncompressed": "'${FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED:-500MB}'", "template": "*.xml" } },
+          { "type": "vsdx;vstx;vssx;vsdm;vstm;vssm", "zip": { "uncompressed": "'${FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED:-500MB}'", "template": "*.xml" } }
+        ],
         "signingKeyStorePath": "/var/www/'${COMPANY_NAME}'/config/signing-keystore.p12"
     }
   },

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -249,6 +249,26 @@ if [ "$METRICS_ENABLED" = "true" ]; then
   jq_set '.statsd.prefix     = $metricsPrefix'
 fi
 
+# FileConverter limits (max upload/conversion size).
+# Both are optional overrides; when unset the built-in default.json values apply.
+# maxDownloadBytes: max size in bytes of the file the converter will download.
+if [ -n "${FILECONVERTER_MAX_DOWNLOAD_BYTES:-}" ]; then
+  case "$FILECONVERTER_MAX_DOWNLOAD_BYTES" in
+    ''|*[!0-9]*) >&2 echo "WARN: FILECONVERTER_MAX_DOWNLOAD_BYTES is not a plain byte count, ignoring" ;;
+    *) jq_set '.FileConverter.converter.maxDownloadBytes = ($maxDownloadBytes | tonumber)' ;;
+  esac
+fi
+# inputLimits: max *uncompressed* size of the office file's zip (e.g. "500MB").
+# Replaces the whole inputLimits array (node-config replaces arrays, not merges).
+if [ -n "${FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED:-}" ]; then
+  jq_set '.FileConverter.converter.inputLimits = [
+    { "type": "docx;dotx;docm;dotm",           "zip": { "uncompressed": $inputLimitUncompressed, "template": "*.xml" } },
+    { "type": "xlsx;xltx;xlsm;xltm",           "zip": { "uncompressed": $inputLimitUncompressed, "template": "*.xml" } },
+    { "type": "pptx;ppsx;potx;pptm;ppsm;potm", "zip": { "uncompressed": $inputLimitUncompressed, "template": "*.xml" } },
+    { "type": "vsdx;vstx;vssx;vsdm;vstm;vssm", "zip": { "uncompressed": $inputLimitUncompressed, "template": "*.xml" } }
+  ]'
+fi
+
 # Construct the AMQP URI value (may be unused if AMQP_HOST=localhost and AMQP_URI unset).
 # AMQP_VHOST is a vhost name (e.g. "myvhost"); normalize to a leading slash before
 # appending to the URI so values without it still produce a valid amqp:// URI.
@@ -290,6 +310,8 @@ jq \
   --arg metricsPort      "$METRICS_PORT" \
   --arg metricsPrefix    "$METRICS_PREFIX" \
   --arg maxFileSize      "$MAX_FILE_SIZE" \
+  --arg maxDownloadBytes       "${FILECONVERTER_MAX_DOWNLOAD_BYTES:-}" \
+  --arg inputLimitUncompressed "${FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED:-}" \
   "$jq_filter" \
   "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"
 mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"


### PR DESCRIPTION
## Context

Fixes #210. Companion server-side PR: https://github.com/Euro-Office/server/pull/35 — **both PRs must be merged together**.

## What changes

### `server` submodule (Euro-Office/server#35)
Bumps the built-in defaults in `Common/config/default.json`:
- `maxDownloadBytes`: 100 MB → 500 MB
- All `inputLimits` uncompressed zip sizes: 50 MB / 300 MB → 500 MB

### `build/scripts/orchestrated/docker-entrypoint.sh`
Fixes a single-quote escaping bug that caused env vars inside `NODE_CONFIG='...'` to be emitted literally (invalid JSON, silently ignored). Adds two runtime overrides:
- `FILECONVERTER_MAX_DOWNLOAD_BYTES` — max file download size in bytes (default 500 MB)
- `FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED` — max uncompressed zip size for docx/xlsx/pptx/vsdx (default 500 MB)

### `build/scripts/standalone/entrypoint.sh`
Adds the same two env vars for the standalone (single-container) image, using the existing `jq_set` pattern. Without this the env vars were silently ignored in standalone deployments.

## Testing

Verified with a 144 MB synthetic `.docx` file (incompressible random-noise PNGs):
- File exceeds old 100 MB / 50 MB limits → would have been rejected before this fix
- Opens successfully with the new 500 MB defaults
- Env var override confirmed: setting `FILECONVERTER_MAX_DOWNLOAD_BYTES=10485760` (10 MB) causes the file to be rejected; removing it restores the 500 MB default

Assisted-by: ClaudeCode:claude-sonnet-4-6