### PR TITLE
fix: Adding SELinux flags for compose file volumes

### DIFF
--- a/develop/docker-compose.yml
+++ b/develop/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       JWT_SECRET: ${EO_JWT_SECRET:-euro-office-dev-jwt-secret-key-2026}
       THEME: euro-office
     volumes:
-      - ../:/develop # mounts deployed files to application
-      - ./setup/Makefile:/Makefile # mounts deployed files to application
+      - ../:/develop:z # mounts deployed files to application
+      - ./setup/Makefile:/Makefile:z # mounts deployed files to application
   nextcloud:
     image: nextcloud:${NC_VERSION:-latest}
     container_name: nextcloud
@@ -29,8 +29,8 @@ services:
       - "8081:80"
     volumes:
       - nc_data:/var/www/html
-      - ./setup/enable-office.sh:/docker-entrypoint-hooks.d/post-installation/enable-office.sh:ro
-      - ../../eurooffice-nextcloud:/var/www/html/custom_apps/eurooffice:ro
+      - ./setup/enable-office.sh:/docker-entrypoint-hooks.d/post-installation/enable-office.sh:ro,z
+      - ../../eurooffice-nextcloud:/var/www/html/custom_apps/eurooffice:ro,z
     environment:
       # 10.0.2.2 = Android emulator's alias for host. Mobile/LAN IPs are
       # applied post-boot by `make refresh-urls` so the container env stays


### PR DESCRIPTION
`enable-office.sh` wasn't able to run during setup, because the executable flags won't get carried over by default if SELinux is present. This add the :z flag for all mounts.

Fixes a part of: https://github.com/Euro-Office/DocumentServer/issues/245
