### PR TITLE
Harden actions fork guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -325,7 +325,7 @@ jobs:
           NUGET_CACHE: local
 
       - name: Upload packages to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: matrix.brand.name == 'euro-office' && startsWith(github.ref, 'refs/tags/')
         with:
           files: |
@@ -439,6 +439,8 @@ jobs:
     if: |
       !cancelled() &&
       needs.build.result == 'success' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
       (github.event_name == 'pull_request' ||
        ((github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/tags/'))
         && needs.manifest.result == 'success'))
@@ -449,6 +451,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Determine image
         id: image
@@ -462,7 +466,7 @@ jobs:
           fi
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -472,7 +476,7 @@ jobs:
         run: docker pull ${{ steps.image.outputs.ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -494,7 +498,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-${{ github.sha }}
           path: e2e/playwright-report/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: ["**"]
+    paths: [".github/workflows/**"]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          inputs: ./.github/workflows


### PR DESCRIPTION
Close #266 


## Summary

- Block fork pull requests from reaching the self-hosted `e2e` runner in `build.yml`, instead of
  relying on an incidental clone-token failure as the only backstop
- Pin 4 floating action references (`action-gh-release`, `docker/login-action`, `actions/setup-node`,
  `actions/upload-artifact`) to exact commit SHAs so a compromised upstream tag can't silently change
  what code runs in this pipeline
- Drop `persist-credentials: false` on the `e2e` job's checkout — no step in that job needs to push
  back to the repo, so there's no reason to leave the token on disk
- Add `zizmor` as a dedicated GitHub Actions security linter, running on any push/PR that touches
  `.github/workflows/**` and uploading results to the repo's Security tab

## Why

Reviewing this repo's CI/CD setup surfaced a few gaps worth closing regardless of any specific
incident: the self-hosted e2e job was only *incidentally* unreachable from fork PRs, four actions were
pinned to mutable tags rather than fixed commits, and there was no automated security linting on
workflow changes going forward. This closes those gaps and documents what's left.

## Test plan

- [ ] `actionlint .github/workflows/build.yml` — no new errors
- [ ] Confirm a same-repo PR still triggers the `e2e` job (self-hosted) as before
- [ ] Confirm a fork PR's `e2e` job shows as skipped, not `action_required`-gated
- [ ] Confirm the new `zizmor` workflow runs successfully on this PR and reports results (check the
      Actions tab / Security tab for this run)
- [ ] Confirm `build.yml`'s existing behavior (Docker build/push, release upload, Playwright report
      upload) is unaffected — no functional changes, only pin format and added guard conditions
