### PR TITLE
feat(triage): persist selected triagers in initial issue comment

### DIFF
--- a/.github/workflows/auto-ping-triagers.yml
+++ b/.github/workflows/auto-ping-triagers.yml
@@ -42,6 +42,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `${mentions} Please triage this community-created issue within 48 hours.`,
+              body: [
+                      '<!-- community-triage-request -->',          // tags required for: 
+                      `<!-- triagers: ${picked.join(',')} -->`,     // remind-community-issue-triage.yml
+                      `${mentions} Please triage this community-created issue within 48 hours.`,
+                    ].join('\n'),
             });
             core.info(`Requested community triage from: ${picked.join(', ')}`);


### PR DESCRIPTION
Store the usernames selected for community issue triage in invisible HTML comment markers alongside the existing public notification.

The public comment remains unchanged for contributors, while the stored metadata allows the scheduled reminder workflow to identify the same two triagers after the issue has remained open for:
>96 hours && <100 days && not assignned to any developer