### PR TITLE
fix(docker): apply Postgres schema on first boot

### DIFF
--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -56,8 +56,11 @@ RUN apt-get update && \
     echo "${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW} ds/db-name string eurooffice" | debconf-set-selections && \
     DS_DOCKER_INSTALLATION=true apt-get install -yq /tmp/${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW}_${PRODUCT_VERSION}-${BUILD_NUMBER}_${TARGETARCH}.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/*
-# Postgres schema is applied at container boot (entrypoint.sh's ensure_db_schema),
-# not at build time: build-time application doesn't survive a fresh DB volume.
+# The .deb postinst applies server/schema/postgresql/createdb.sql at build time
+# (postinst.m4: install_db is not gated on DS_DOCKER_INSTALLATION), which is why the
+# explicit psql call that used to live here was redundant. It does not help when the
+# Postgres datadir is a fresh volume or DB_HOST points at an external server, so
+# entrypoint.sh re-applies it idempotently at boot (ensure_db_schema).
 
 # --- Final setup ---
 COPY build/configs/standalone/supervisor/ /etc/supervisor/conf.d/

--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -56,7 +56,8 @@ RUN apt-get update && \
     echo "${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW} ds/db-name string eurooffice" | debconf-set-selections && \
     DS_DOCKER_INSTALLATION=true apt-get install -yq /tmp/${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW}_${PRODUCT_VERSION}-${BUILD_NUMBER}_${TARGETARCH}.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/*
-    #sudo -u postgres bash -c "PGPASSWORD=eurooffice psql -h localhost -U eurooffice -d eurooffice -f ${EO_ROOT}/server/schema/postgresql/createdb.sql"
+# Postgres schema is applied at container boot (entrypoint.sh's ensure_db_schema),
+# not at build time: build-time application doesn't survive a fresh DB volume.
 
 # --- Final setup ---
 COPY build/configs/standalone/supervisor/ /etc/supervisor/conf.d/

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -422,10 +422,6 @@ fi
 # for it above.
 # --------------------------------------------------------------------
 [ "$DB_HOST"            = "localhost" ] && service postgresql start
-[ "$AMQP_HOST"          = "localhost" ] && [ -z "${AMQP_URI:-}" ] && \
-  service rabbitmq-server start
-[ "$REDIS_SERVER_HOST"  = "localhost" ] && service redis-server start
-service nginx start
 
 # --------------------------------------------------------------------
 # Apply Postgres schema on first boot (idempotent).
@@ -433,6 +429,9 @@ service nginx start
 # The stock image has no init step for this, so a fresh DB volume leaves
 # docservice failing with `DB table "task_result" does not exist` and
 # never binding to :8000 — nginx then serves 502 on /healthcheck.
+#
+# Runs here, right after Postgres starts and before nginx, so the 502
+# window is as small as possible.
 # --------------------------------------------------------------------
 ensure_db_schema() {
   schema_file="${EO_ROOT}/server/schema/postgresql/createdb.sql"
@@ -448,15 +447,16 @@ ensure_db_schema() {
   until db_psql -tAc 'SELECT 1' >/dev/null 2>&1; do
     tries=$((tries + 1))
     if [ "$tries" -gt 60 ]; then
-      echo "ERROR: Postgres not reachable at ${DB_HOST}:${DB_PORT} after 60s" >&2
+      echo "ERROR: could not connect to Postgres at ${DB_HOST}:${DB_PORT} as ${DB_USER}/${DB_NAME} after 60s" >&2
+      db_psql -tAc 'SELECT 1' >&2 || true
       return 1
     fi
     sleep 1
   done
 
   # Probe a table that createdb.sql creates. Skip if already populated.
-  if db_psql -tAc "SELECT to_regclass('public.task_result')::text" 2>/dev/null \
-       | grep -qx 'task_result'; then
+  if [ "$(db_psql -tAc "SELECT to_regclass('public.task_result') IS NOT NULL" 2>/dev/null)" = "t" ]; then
+    echo "Postgres schema already present, skipping."
     return 0
   fi
 
@@ -464,6 +464,11 @@ ensure_db_schema() {
   db_psql -f "$schema_file"
 }
 ensure_db_schema
+
+[ "$AMQP_HOST"          = "localhost" ] && [ -z "${AMQP_URI:-}" ] && \
+  service rabbitmq-server start
+[ "$REDIS_SERVER_HOST"  = "localhost" ] && service redis-server start
+service nginx start
 
 # --------------------------------------------------------------------
 # Fonts + plugins (background where appropriate).

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -426,19 +426,33 @@ fi
 # --------------------------------------------------------------------
 # Apply Postgres schema on first boot (idempotent).
 #
-# The stock image has no init step for this, so a fresh DB volume leaves
-# docservice failing with `DB table "task_result" does not exist` and
-# never binding to :8000 — nginx then serves 502 on /healthcheck.
+# The .deb postinst applies createdb.sql at *image build* time, so the
+# bundled cluster already has the schema. This step exists for the cases
+# build-time application can't cover: an external DB_HOST, or a fresh
+# volume mounted over the Postgres datadir — either leaves docservice
+# failing with `DB table "task_result" does not exist` and never binding
+# to :8000, so nginx serves 502 on /healthcheck.
 #
 # Runs here, right after Postgres starts and before nginx, so the 502
 # window is as small as possible.
+#
+# A failure here is not fatal to boot (see the `||` at the call site
+# below) — the container still starts, just possibly 502ing until the
+# schema is applied out of band, rather than being taken down by set -e.
 # --------------------------------------------------------------------
 ensure_db_schema() {
   schema_file="${EO_ROOT}/server/schema/postgresql/createdb.sql"
   [ -f "$schema_file" ] || return 0
 
+  # DB_PWD is usually unset: the jq rewrite above only touches
+  # sql.dbPass when DB_PWD is non-empty (see :200), so in the default
+  # (stock-image) configuration the real password is whatever postinst
+  # baked into $CONFIG_FILE at build time. Fall back to reading it from
+  # there rather than authenticating with an empty password.
+  db_pwd="${DB_PWD:-$(jq -r '.services.CoAuthoring.sql.dbPass // empty' "$CONFIG_FILE" 2>/dev/null || true)}"
+
   db_psql() {
-    PGPASSWORD="${DB_PWD:-}" psql \
+    PGPASSWORD="$db_pwd" psql -w \
       -v ON_ERROR_STOP=1 \
       -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"
   }
@@ -448,7 +462,10 @@ ensure_db_schema() {
     tries=$((tries + 1))
     if [ "$tries" -gt 60 ]; then
       echo "ERROR: could not connect to Postgres at ${DB_HOST}:${DB_PORT} as ${DB_USER}/${DB_NAME} after 60s" >&2
+      # Re-run once unsuppressed so psql's own message (auth failure vs.
+      # unreachable host) reaches the log instead of our generic one.
       db_psql -tAc 'SELECT 1' >&2 || true
+      unset -f db_psql
       return 1
     fi
     sleep 1
@@ -457,13 +474,15 @@ ensure_db_schema() {
   # Probe a table that createdb.sql creates. Skip if already populated.
   if [ "$(db_psql -tAc "SELECT to_regclass('public.task_result') IS NOT NULL" 2>/dev/null)" = "t" ]; then
     echo "Postgres schema already present, skipping."
+    unset -f db_psql
     return 0
   fi
 
   echo "Applying Postgres schema from ${schema_file}..."
   db_psql -f "$schema_file"
+  unset -f db_psql
 }
-ensure_db_schema
+ensure_db_schema || echo "WARNING: Postgres schema bootstrap failed; docservice may 502 until it is applied." >&2
 
 [ "$AMQP_HOST"          = "localhost" ] && [ -z "${AMQP_URI:-}" ] && \
   service rabbitmq-server start

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -428,6 +428,44 @@ fi
 service nginx start
 
 # --------------------------------------------------------------------
+# Apply Postgres schema on first boot (idempotent).
+#
+# The stock image has no init step for this, so a fresh DB volume leaves
+# docservice failing with `DB table "task_result" does not exist` and
+# never binding to :8000 — nginx then serves 502 on /healthcheck.
+# --------------------------------------------------------------------
+ensure_db_schema() {
+  schema_file="${EO_ROOT}/server/schema/postgresql/createdb.sql"
+  [ -f "$schema_file" ] || return 0
+
+  db_psql() {
+    PGPASSWORD="${DB_PWD:-}" psql \
+      -v ON_ERROR_STOP=1 \
+      -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"
+  }
+
+  tries=0
+  until db_psql -tAc 'SELECT 1' >/dev/null 2>&1; do
+    tries=$((tries + 1))
+    if [ "$tries" -gt 60 ]; then
+      echo "ERROR: Postgres not reachable at ${DB_HOST}:${DB_PORT} after 60s" >&2
+      return 1
+    fi
+    sleep 1
+  done
+
+  # Probe a table that createdb.sql creates. Skip if already populated.
+  if db_psql -tAc "SELECT to_regclass('public.task_result')::text" 2>/dev/null \
+       | grep -qx 'task_result'; then
+    return 0
+  fi
+
+  echo "Applying Postgres schema from ${schema_file}..."
+  db_psql -f "$schema_file"
+}
+ensure_db_schema
+
+# --------------------------------------------------------------------
 # Fonts + plugins (background where appropriate).
 # --------------------------------------------------------------------
 if [ "$GENERATE_FONTS" = "true" ] && command -v /usr/bin/documentserver-generate-allfonts.sh >/dev/null 2>&1; then

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -480,7 +480,9 @@ ensure_db_schema() {
 
   echo "Applying Postgres schema from ${schema_file}..."
   db_psql -f "$schema_file"
+  rc=$?
   unset -f db_psql
+  return "$rc"
 }
 ensure_db_schema || echo "WARNING: Postgres schema bootstrap failed; docservice may 502 until it is applied." >&2
 


### PR DESCRIPTION
## Problem it solves
on a fresh startup the healthcheck stays on bad gateway

## Approach taken
Added `ensure_db_schema()` to `build/scripts/standalone/entrypoint.sh`, invoked once after `service nginx start`. It:

- No-ops if `${EO_ROOT}/server/schema/postgresql/createdb.sql` isn't present.
- Polls Postgres via `psql -tAc 'SELECT 1'` (1s interval, 60s cap) before doing anything.
- Checks `to_regclass('public.task_result')` to detect an already-applied schema and skip re-running.
- Otherwise applies `createdb.sql` via `psql -f`.

Reuses only vars already present in the script (`EO_ROOT`, `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_NAME`, `DB_PWD`) — no new env vars, no other files touched.

## Testing
tested on 2 live instances


**Branch:** `fix/ensure-db-schema-on-boot`
