### PR TITLE
feat(docker): add upload/tempfile size limit env vars to standalone e…

### DIFF
--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -16,6 +16,7 @@ EXAMPLE_LOCAL="${EXAMPLE_CONF_DIR}/local.json"
 NGINX_CONFIG_PATH="/etc/nginx/nginx.conf"
 NGINX_DS_DIR="${EO_CONF}/nginx"
 NGINX_DS_CONF="${NGINX_DS_DIR}/ds.conf"
+NGINX_DS_COMMON_CONF="${NGINX_DS_DIR}/includes/ds-common.conf"
 NGINX_DS_SSL_TMPL="${NGINX_DS_DIR}/ds-ssl.conf.tmpl"
 SUPERVISOR_CONF_DIR="/etc/supervisor/conf.d"
 
@@ -46,8 +47,11 @@ METRICS_PORT="${METRICS_PORT:-8125}"
 METRICS_PREFIX="${METRICS_PREFIX:-ds.}"
 GENERATE_FONTS="${GENERATE_FONTS:-true}"
 
+MAX_FILE_SIZE="${MAX_FILE_SIZE:-104857600}"
+
 NGINX_WORKER_PROCESSES="${NGINX_WORKER_PROCESSES:-1}"
 NGINX_ACCESS_LOG="${NGINX_ACCESS_LOG:-false}"
+NGINX_CLIENT_MAX_BODY_SIZE="${NGINX_CLIENT_MAX_BODY_SIZE:-100m}"
 SSL_VERIFY_CLIENT="${SSL_VERIFY_CLIENT:-off}"
 ONLYOFFICE_HTTPS_HSTS_ENABLED="${ONLYOFFICE_HTTPS_HSTS_ENABLED:-true}"
 ONLYOFFICE_HTTPS_HSTS_MAXAGE="${ONLYOFFICE_HTTPS_HSTS_MAXAGE:-31536000}"
@@ -234,6 +238,9 @@ fi
 [ "$ALLOW_META_IP_ADDRESS" = "true" ] && \
   jq_set '.services.CoAuthoring["request-filtering-agent"].allowMetaIPAddress = true'
 
+# Upload size limit
+jq_set '.services.CoAuthoring.server.limits_tempfile_upload = ($maxFileSize | tonumber? // $maxFileSize)'
+
 # Metrics (statsd)
 if [ "$METRICS_ENABLED" = "true" ]; then
   jq_set '.statsd.useMetrics = true'
@@ -282,6 +289,7 @@ jq \
   --arg metricsHost      "$METRICS_HOST" \
   --arg metricsPort      "$METRICS_PORT" \
   --arg metricsPrefix    "$METRICS_PREFIX" \
+  --arg maxFileSize      "$MAX_FILE_SIZE" \
   "$jq_filter" \
   "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"
 mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
@@ -310,6 +318,10 @@ if [ -f "$NGINX_CONFIG_PATH" ]; then
   else
     sed -ri "s|^\s*access_log\b.*;|access_log off;|" "$NGINX_CONFIG_PATH"
   fi
+fi
+
+if [ -f "$NGINX_DS_COMMON_CONF" ]; then
+  sed -i "s/client_max_body_size[[:space:]]\+[^;]\+;/client_max_body_size ${NGINX_CLIENT_MAX_BODY_SIZE};/" "$NGINX_DS_COMMON_CONF"
 fi
 
 if [ -n "${SSL_CERTIFICATE_PATH:-}" ] && [ -n "${SSL_KEY_PATH:-}" ] \
@@ -359,12 +371,14 @@ enable_supervisor_program() {
 # --------------------------------------------------------------------
 if [ "${EXAMPLE_ENABLED:-false}" = "true" ] && [ -d "$EXAMPLE_CONF_DIR" ]; then
   jq -n \
-    --arg secret "$JWT_SECRET" \
-    --arg header "$JWT_HEADER" \
+    --arg secret      "$JWT_SECRET" \
+    --arg header      "$JWT_HEADER" \
+    --arg maxFileSize "$MAX_FILE_SIZE" \
     '{
       "server": {
         "siteUrl": "/",
         "exampleUrl": "http://localhost/example/",
+        "maxFileSize": ($maxFileSize | tonumber? // $maxFileSize),
         "token": {
           "enable": true,
           "secret": $secret,


### PR DESCRIPTION
## Problem it solves
before changing to euro-office I encountered this issue in OpenOffice doc server, so I audited euro office for the same issue since the fix is a requirement for our environment


## Approach taken
Extended `build/scripts/standalone/entrypoint.sh` with two new env-var-driven defaults:

- `MAX_FILE_SIZE` (default `104857600`, i.e. 100MB) → sets `services.CoAuthoring.server.limits_tempfile_upload` in the generated config, and `maxFileSize` in the example app's `local.json` (both via `tonumber? // ` so non-numeric values pass through as strings rather than erroring).
- `NGINX_CLIENT_MAX_BODY_SIZE` (default `100m`) → patches the `client_max_body_size` directive in `${NGINX_DS_DIR}/includes/ds-common.conf` via `sed`, gated on that file existing.

**Scope note:** deliberately does *not* touch `FileConverter.converter.maxDownloadBytes` or `.inputLimits[].zip.uncompressed` — PR #237 already introduces `FILECONVERTER_MAX_DOWNLOAD_BYTES` and `FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED` for exactly those two settings. This PR was split out of an earlier branch that duplicated them under different env-var names/mechanism; keeping this PR scoped to the settings #237 doesn't cover avoids two competing controls for one config key.

## Testing
merged locally 
https://github.com/ckbaker10/DocumentServer/blob/test/upload-size-limits-plus-237/build/scripts/standalone/entrypoint.sh
tested with 100m xlsm 

## Related
Split out of the original `feat-file-size` branch per review; scoped to not conflict with #237.


**Branch:** `feat/upload-size-limits`
