### PR TITLE
fix(docker): start rabbitmq directly and wait for readiness

### DIFF
--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -40,12 +40,19 @@ RUN apt-get update && \
 #RUN useradd -r -s /bin/false ds || true
 
 # --- install ${COMPANY_NAME_LOW} .deb package
+# RabbitMQ is started directly rather than via `service rabbitmq-server start`
+# for the same reason as in entrypoint.sh: the init script's
+# `start-stop-daemon --background` wedges under a huge RLIMIT_NOFILE, which
+# would hang the build on hosts that hand containers one (#326). Its mnesia
+# database is dropped again afterwards -- the node name follows the container
+# hostname, so `rabbit@buildkitsandbox` is never read at runtime.
 ARG TARGETARCH
 COPY --from=packages / /tmp/
 RUN apt-get update && \
     (pg_createcluster 16 main || true) && \
     service postgresql start && \
-    service rabbitmq-server start && \
+    runuser -u rabbitmq -- rabbitmq-server -detached && \
+    runuser -u rabbitmq -- rabbitmqctl await_startup --timeout 60 && \
     sudo -u postgres psql -c "CREATE USER eurooffice WITH password 'eurooffice';" && \
     sudo -u postgres psql -c "CREATE DATABASE eurooffice OWNER eurooffice;" && \
     echo "${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW} ds/db-type string postgres" | debconf-set-selections && \
@@ -55,7 +62,8 @@ RUN apt-get update && \
     echo "${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW} ds/db-pwd password eurooffice" | debconf-set-selections && \
     echo "${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW} ds/db-name string eurooffice" | debconf-set-selections && \
     DS_DOCKER_INSTALLATION=true apt-get install -yq /tmp/${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW}_${PRODUCT_VERSION}-${BUILD_NUMBER}_${TARGETARCH}.deb && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
+    (runuser -u rabbitmq -- rabbitmqctl shutdown || true) && \
+    rm -rf /var/lib/rabbitmq/mnesia /var/lib/apt/lists/* /tmp/*
 # The .deb postinst applies server/schema/postgresql/createdb.sql at build time
 # (postinst.m4: install_db is not gated on DS_DOCKER_INSTALLATION), which is why the
 # explicit psql call that used to live here was redundant. It does not help when the

--- a/build/.docker/standalone.bake.Dockerfile
+++ b/build/.docker/standalone.bake.Dockerfile
@@ -46,13 +46,23 @@ RUN apt-get update && \
 # would hang the build on hosts that hand containers one (#326). Its mnesia
 # database is dropped again afterwards -- the node name follows the container
 # hostname, so `rabbit@buildkitsandbox` is never read at runtime.
+#
+# The readiness wait is a poll for the same reason as start_rabbitmq() in
+# entrypoint.sh: `-detached` returns before the node registers with epmd, and
+# until it does `rabbitmqctl await_startup` fails outright instead of waiting
+# out its timeout. A single call therefore lost the race on three of four CI
+# builders, exiting 69 after seven seconds with "epmd reports: node 'rabbit'
+# not running at all". On timeout the wait is repeated unsuppressed so
+# rabbitmqctl's own diagnostics reach the build log before the build fails.
 ARG TARGETARCH
 COPY --from=packages / /tmp/
 RUN apt-get update && \
     (pg_createcluster 16 main || true) && \
     service postgresql start && \
     runuser -u rabbitmq -- rabbitmq-server -detached && \
-    runuser -u rabbitmq -- rabbitmqctl await_startup --timeout 60 && \
+    ( timeout 60 runuser -u rabbitmq -- sh -c \
+        'until rabbitmqctl -q await_startup --timeout 5 >/dev/null 2>&1; do sleep 1; done' \
+      || runuser -u rabbitmq -- rabbitmqctl await_startup --timeout 5 ) && \
     sudo -u postgres psql -c "CREATE USER eurooffice WITH password 'eurooffice';" && \
     sudo -u postgres psql -c "CREATE DATABASE eurooffice OWNER eurooffice;" && \
     echo "${COMPANY_NAME_LOW}-${PRODUCT_NAME_LOW} ds/db-type string postgres" | debconf-set-selections && \

--- a/build/scripts/standalone/entrypoint.sh
+++ b/build/scripts/standalone/entrypoint.sh
@@ -35,6 +35,8 @@ DB_USER="${DB_USER:-eurooffice}"
 
 AMQP_HOST="${AMQP_HOST:-localhost}"
 AMQP_PORT="${AMQP_PORT:-5672}"
+# Seconds to wait for the bundled RabbitMQ to report itself ready (start_rabbitmq).
+AMQP_START_TIMEOUT="${AMQP_START_TIMEOUT:-60}"
 
 REDIS_SERVER_HOST="${REDIS_SERVER_HOST:-localhost}"
 REDIS_SERVER_PORT="${REDIS_SERVER_PORT:-6379}"
@@ -522,8 +524,43 @@ ensure_db_schema() {
 }
 ensure_db_schema || echo "WARNING: Postgres schema bootstrap failed; docservice may 502 until it is applied." >&2
 
-[ "$AMQP_HOST"          = "localhost" ] && [ -z "${AMQP_URI:-}" ] && \
-  service rabbitmq-server start
+# --------------------------------------------------------------------
+# Start the bundled RabbitMQ.
+#
+# Deliberately not `service rabbitmq-server start`: that init script goes
+# through `start-stop-daemon --background`, which wedges for many minutes on
+# hosts whose Docker daemon hands containers a huge RLIMIT_NOFILE (some
+# distro-packaged daemons default it to 1073741816). The entrypoint then never
+# reaches nginx/supervisord and the container looks hung with no diagnostic
+# (#326). A direct detached start is unaffected, and pairing it with an
+# explicit readiness wait means a real startup failure is reported here
+# instead of surfacing later as unexplained 502s from docservice.
+#
+# Not fatal to boot, like the schema bootstrap above: the container stays up
+# and inspectable, and /healthcheck fails until AMQP is reachable.
+# --------------------------------------------------------------------
+start_rabbitmq() {
+  echo "Starting RabbitMQ Messaging Server rabbitmq-server"
+  runuser -u rabbitmq -- rabbitmq-server -detached || return 1
+
+  # `-detached` returns before the node registers with epmd, and until it does
+  # await_startup fails outright instead of waiting, so poll it.
+  deadline=$(( $(date +%s) + AMQP_START_TIMEOUT ))
+  until runuser -u rabbitmq -- rabbitmqctl -q await_startup --timeout 5 >/dev/null 2>&1; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      # Re-run unsuppressed so rabbitmqctl's own diagnostics reach the log.
+      runuser -u rabbitmq -- rabbitmqctl await_startup --timeout 5 >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+  echo "   ...done."
+}
+
+if [ "$AMQP_HOST" = "localhost" ] && [ -z "${AMQP_URI:-}" ]; then
+  start_rabbitmq \
+    || echo "ERROR: RabbitMQ did not become ready within ${AMQP_START_TIMEOUT}s; docservice will fail to connect." >&2
+fi
 [ "$REDIS_SERVER_HOST"  = "localhost" ] && service redis-server start
 service nginx start
 


### PR DESCRIPTION
PR #249 switched the standalone entrypoint from a direct detached start to `service rabbitmq-server start` for consistency with postgres and redis. The init script goes through `start-stop-daemon --background`, which wedges under a very large RLIMIT_NOFILE. Docker daemons that pass one through to containers (26.1.5+dfsg1 defaulting to 1073741816 was reported twice) leave the entrypoint stuck before nginx and supervisord ever start: the container looks hung, /healthcheck resets the connection, and nothing in the log says why. Setting `ulimits.nofile` in compose is a workaround, but users have no way to know that is what is wrong.

Go back to `rabbitmq-server -detached`, which is unaffected, and follow it with a bounded `rabbitmqctl await_startup` poll (AMQP_START_TIMEOUT, default 60s). `-detached` returns before the node registers with epmd, so a single await_startup call fails outright and has to be polled. A timeout now logs rabbitmqctl's own diagnostics and continues to supervisord, like the schema bootstrap above it, so the failure is visible instead of silent.

Apply the same at image build time, where the identical hang would break builds on affected hosts, and drop the mnesia database the build leaves behind: the node name follows the container hostname, so the baked `rabbit@buildkitsandbox` directory is never read at runtime.

Fixes #326

Assisted-by: ClaudeCode:claude-opus-5