### PR TITLE
ci: gate on sdk-all.js compiling under the real no-ICU V8

### DIFF
--- a/.github/actions/pull-built-image/action.yml
+++ b/.github/actions/pull-built-image/action.yml
@@ -1,0 +1,49 @@
+name: 'Resolve and pull built image'
+description: >
+  Resolves the DocumentServer image tag for the current event (PR cache tag
+  on pull_request, :latest on a release tag, :nightly otherwise), logs in to
+  GHCR, and pulls it. Shared by any job that runs something against the
+  already-built image (e2e, post-build smoke checks, ...) so the
+  tag-resolution + login + pull sequence exists in exactly one place.
+
+inputs:
+  registry:
+    description: 'Container registry host, e.g. ghcr.io/euro-office'
+    required: true
+  image-name:
+    description: 'Image name used for :nightly / :latest tags'
+    required: true
+  cache-image-name:
+    description: 'Image name used for the per-PR cache tag'
+    required: true
+
+outputs:
+  ref:
+    description: 'Fully-qualified image ref that was pulled'
+    value: ${{ steps.image.outputs.ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Determine image
+      id: image
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "ref=${{ inputs.registry }}/${{ inputs.cache-image-name }}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          echo "ref=${{ inputs.registry }}/${{ inputs.image-name }}:latest" >> "$GITHUB_OUTPUT"
+        else
+          echo "ref=${{ inputs.registry }}/${{ inputs.image-name }}:nightly" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Pull built image
+      shell: bash
+      run: docker pull "${{ steps.image.outputs.ref }}"

--- a/.github/actions/pull-built-image/action.yml
+++ b/.github/actions/pull-built-image/action.yml
@@ -46,4 +46,6 @@ runs:
 
     - name: Pull built image
       shell: bash
-      run: docker pull "${{ steps.image.outputs.ref }}"
+      env:
+        IMAGE_REF: ${{ steps.image.outputs.ref }}
+      run: docker pull "$IMAGE_REF"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -461,26 +461,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Determine image
-        id: image
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "ref=${{ env.REGISTRY }}/${{ env.CACHE_IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
-          else
-            echo "ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+      - name: Pull built image
+        id: pull
+        uses: ./.github/actions/pull-built-image
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull built image
-        run: docker pull ${{ steps.image.outputs.ref }}
+          image-name: ${{ env.IMAGE_NAME }}
+          cache-image-name: ${{ env.CACHE_IMAGE_NAME }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -500,7 +487,7 @@ jobs:
       - name: Run E2E tests
         working-directory: e2e
         env:
-          E2E_IMAGE: ${{ steps.image.outputs.ref }}
+          E2E_IMAGE: ${{ steps.pull.outputs.ref }}
         run: npm test
 
       - name: Upload Playwright report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,3 +497,61 @@ jobs:
           name: playwright-report-${{ github.sha }}
           path: e2e/playwright-report/
           retention-days: 14
+
+  # Asserts the shipped sdk-all.js bundles actually compile under the real,
+  # no-ICU V8 that x2t/doctrenderer embeds — not just under Node/Chromium
+  # (both full-ICU, so CI JS checks structurally cannot catch this class of
+  # bug). This is the reproduction recipe from Euro-Office/sdkjs#80 (Terser
+  # emitted bare astral-plane object keys; the no-ICU V8 rejected them and
+  # x2t aborted on every save) turned into a CI assertion. Runs against the
+  # same already-built image as e2e, independently of it, so a V8-compile
+  # regression fails loud here in seconds rather than surfacing as a broken
+  # save with no diagnostic.
+  sdkjs-v8-smoke:
+    runs-on: self-hosted
+    needs: build
+    if: |
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Pull built image
+        id: pull
+        uses: ./.github/actions/pull-built-image
+        with:
+          registry: ${{ env.REGISTRY }}
+          image-name: ${{ env.IMAGE_NAME }}
+          cache-image-name: ${{ env.CACHE_IMAGE_NAME }}
+
+      - name: Compile sdk-all.js under the real no-ICU V8 (x2t -create-js-cache)
+        run: |
+          docker run --rm --entrypoint bash "${{ steps.pull.outputs.ref }}" -c '
+            set -euo pipefail
+            DIR=/var/www/euro-office/documentserver
+            export LD_LIBRARY_PATH="$DIR/server/FileConverter/bin:${LD_LIBRARY_PATH:-}"
+
+            rm -f "$DIR"/sdkjs/*/sdk-all.cache
+            cd "$DIR/server/FileConverter/bin"
+            ./x2t -create-js-cache
+
+            fail=0
+            for module in word cell slide visio; do
+              size=$(stat -c %s "$DIR/sdkjs/$module/sdk-all.cache" 2>/dev/null || echo 0)
+              echo "$module: sdk-all.cache = ${size} bytes"
+              if [ "$size" -eq 0 ]; then
+                echo "::error::$module/sdk-all.cache is empty or missing — V8 failed to compile sdk-all.js (see Euro-Office/sdkjs#80)"
+                fail=1
+              fi
+            done
+            exit $fail
+          '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -534,8 +534,10 @@ jobs:
           cache-image-name: ${{ env.CACHE_IMAGE_NAME }}
 
       - name: Compile sdk-all.js under the real no-ICU V8 (x2t -create-js-cache)
+        env:
+          IMAGE_REF: ${{ steps.pull.outputs.ref }}
         run: |
-          docker run --rm --entrypoint bash "${{ steps.pull.outputs.ref }}" -c '
+          docker run --rm --entrypoint bash "$IMAGE_REF" -c '
             set -euo pipefail
             DIR=/var/www/euro-office/documentserver
             export LD_LIBRARY_PATH="$DIR/server/FileConverter/bin:${LD_LIBRARY_PATH:-}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,7 +514,10 @@ jobs:
       !cancelled() &&
       needs.build.result == 'success' &&
       (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name == 'pull_request' ||
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ||
+       startsWith(github.ref, 'refs/tags/'))
     permissions:
       contents: read
       packages: read
@@ -538,15 +541,22 @@ jobs:
           IMAGE_REF: ${{ steps.pull.outputs.ref }}
         run: |
           docker run --rm --entrypoint bash "$IMAGE_REF" -c '
-            set -euo pipefail
+            set -uo pipefail
             DIR=/var/www/euro-office/documentserver
             export LD_LIBRARY_PATH="$DIR/server/FileConverter/bin:${LD_LIBRARY_PATH:-}"
 
             rm -f "$DIR"/sdkjs/*/sdk-all.cache
             cd "$DIR/server/FileConverter/bin"
-            ./x2t -create-js-cache
+
+            rc=0
+            ./x2t -create-js-cache || rc=$?
 
             fail=0
+            if [ "$rc" -ne 0 ]; then
+              echo "::error::x2t -create-js-cache exited $rc — V8 likely aborted compiling sdk-all.js (see Euro-Office/sdkjs#80)"
+              fail=1
+            fi
+
             for module in word cell slide visio; do
               size=$(stat -c %s "$DIR/sdkjs/$module/sdk-all.cache" 2>/dev/null || echo 0)
               echo "$module: sdk-all.cache = ${size} bytes"


### PR DESCRIPTION
## Summary

- Adds a `sdkjs-v8-smoke` job that runs the reproduction recipe from
  Euro-Office/sdkjs#80 as a CI gate: pull the built image, run
  `x2t -create-js-cache` for word/cell/slide/visio, fail if any resulting
  `sdk-all.cache` is empty.
- Extracts the tag-resolution + GHCR login + pull sequence (previously only
  in `e2e`) into `.github/actions/pull-built-image`, since this PR needed
  the same sequence a second time and copy-pasting it again seemed like the
  wrong move.

## Why

#80: a Terser change emitted bare astral-plane object keys in `sdk-all.js`.
Node/Chromium (both full-ICU) parse them fine, but `x2t`/`doctrenderer`
embed a V8 built with `v8_enable_i18n_support=false`, which rejects them —
every document save aborted. `check-build.yml` validates bundles with
Node and headless Chromium only, so nothing in CI could have caught this.
This turns the incident's own manual repro into an automated gate, so a
future regression of the same class fails loud in seconds with a pointer
back to #80, instead of surfacing later as an unexplained save failure.

## Test plan

- [x] Both YAML files validated (`yaml.safe_load`)
- [ ] CI run on this PR — `sdkjs-v8-smoke` should pass against the current
      good bundle; will report back once it's run
- [ ] Reviewer: worth double-checking the `LD_LIBRARY_PATH`/path assumptions
      (`/var/www/euro-office/documentserver/...`) still match the current
      image layout

Assisted-by: ClaudeCode:claude-sonnet-5